### PR TITLE
Update ruff action to enforce lint violations with --exit-non-zero-on-fix and --diff

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
         with:
-          args: check --output-format=github --fix .
+          args: check --output-format=github --fix --exit-non-zero-on-fix --diff .
       - uses: astral-sh/ruff-action@v3
         with:
           args: format --check .


### PR DESCRIPTION
Updates the Ruff GitHub Actions workflow to enforce lint standards in CI by failing the job when fixable lint violations are present.

The `ruff check` step now uses `--fix --exit-non-zero-on-fix --diff` so that:
- CI fails whenever there are auto-fixable lint violations, rather than silently applying fixes without committing them.
- A diff is shown in the CI output, making it easy to identify exactly what needs to be corrected locally.

A separate `ruff format --check` step continues to enforce formatting.