### PR TITLE
69 allow for arbitrary ordering of spatial dimensions

### DIFF
--- a/src/offline_particles/fields.py
+++ b/src/offline_particles/fields.py
@@ -13,7 +13,7 @@ import numpy as np
 import numpy.typing as npt
 import xarray as xr
 
-from .spatial_arrays import ArrayAxis, BBox, ChunkedDaskArray, NumpyArray, SpatialArray, Stagger
+from .spatial_arrays import ArrayAxis, ArrayLayout, BBox, ChunkedDaskArray, NumpyArray, SpatialArray, Stagger
 
 logger = logging.getLogger(__name__)
 
@@ -27,80 +27,63 @@ class FieldData:
         return f"FieldData(array(shape={self.array.shape}, dtype={self.array.dtype}), offsets={self.offsets})"
 
 
+@dataclasses.dataclass(frozen=True, slots=True)
+class SimulationSize:
+    time: int
+    z: int
+    y: int
+    x: int
+
+    def axis_size(self, axis: ArrayAxis) -> int:
+        match axis:
+            case ArrayAxis.Z:
+                return self.z
+            case ArrayAxis.Y:
+                return self.y
+            case ArrayAxis.X:
+                return self.x
+            case _:
+                raise ValueError(f"Invalid axis: {axis}")
+
+
 class Field(abc.ABC):
     """Abstract base class for fields used in particle simulations."""
 
     def __init__(
         self,
-        z_stagger: Stagger,
-        y_stagger: Stagger,
-        x_stagger: Stagger,
+        layout: ArrayLayout,
         *,
         attrs: dict[str, Any] | None = None,
     ) -> None:
-        self._z_stagger = z_stagger
-        self._y_stagger = y_stagger
-        self._x_stagger = x_stagger
-        self._z_offset = z_stagger.offset
-        self._y_offset = y_stagger.offset
-        self._x_offset = x_stagger.offset
+        self._layout = layout
         if attrs is None:
             attrs = {}
         self._attrs = attrs
 
     @property
-    def z_stagger(self) -> Stagger:
-        """Staggering in the vertical direction."""
-        return self._z_stagger
+    def ndim(self) -> int:
+        """Number of dimensions in the spatial array."""
+        return self._layout.ndim
 
     @property
-    def y_stagger(self) -> Stagger:
-        """Stagger in the eta (y) direction."""
-        return self._y_stagger
+    def axes(self) -> tuple[ArrayAxis, ...]:
+        """Axes of the spatial array."""
+        return self._layout.axes
 
     @property
-    def x_stagger(self) -> Stagger:
-        """Stagger in the xi (x) direction."""
-        return self._x_stagger
+    def staggers(self) -> tuple[Stagger, ...]:
+        """Staggering of the dimensions."""
+        return self._layout.staggers
 
     @property
-    def stagger(self) -> tuple[Stagger, Stagger, Stagger]:
-        """Staggering of the (z, y, x) dimensions."""
-        return (self._z_stagger, self._y_stagger, self._x_stagger)
+    def offsets(self) -> tuple[float]:
+        """Offsets for all dimensions."""
+        return self._layout.offsets
 
     @property
     def attrs(self) -> dict[str, Any]:
         """Attributes associated with the field."""
         return self._attrs
-
-    @property
-    def z_offset(self) -> float | None:
-        """Offset of the z dimension."""
-        return self._z_offset
-
-    @property
-    def y_offset(self) -> float | None:
-        """Offset of the y dimension."""
-        return self._y_offset
-
-    @property
-    def x_offset(self) -> float | None:
-        """Offset of the x dimension."""
-        return self._x_offset
-
-    @property
-    def all_offsets(self) -> tuple[float | None, float | None, float | None]:
-        """Offset of the (z, y, x) dimensions."""
-        return (self._z_offset, self._y_offset, self._x_offset)
-
-    @property
-    def dmask(self) -> tuple[bool, bool, bool]:
-        """Mask indicating which dimensions are active."""
-        return (
-            self._z_stagger.is_active,
-            self._y_stagger.is_active,
-            self._x_stagger.is_active,
-        )
 
     @property
     @abc.abstractmethod
@@ -121,13 +104,12 @@ class Field(abc.ABC):
         pass
 
     @property
-    @abc.abstractmethod
     def nspatial_dims(self) -> int:
         """Number of spatial dimensions of the field."""
-        pass
+        return self._layout.ndim
 
     @abc.abstractmethod
-    def validate_shape(self, simulation_shape: tuple[int, int, int, int]) -> None:
+    def validate_shape(self, simulation_shape: SimulationSize) -> None:
         """Validate that the field's shape is compatible with the domain shape."""
         pass
 
@@ -160,9 +142,7 @@ class StaticField(Field):
         attrs: dict[str, Any] | None = None,
     ):
         super().__init__(
-            z_stagger=data.z_stagger,
-            y_stagger=data.y_stagger,
-            x_stagger=data.x_stagger,
+            layout=data.layout,
             attrs=attrs,
         )
         self._data = data
@@ -173,15 +153,10 @@ class StaticField(Field):
         return self._data
 
     def __repr__(self) -> str:
-        return (
-            f"StaticField(shape={self._data.shape}, "
-            f"z_stagger={self.z_stagger}, "
-            f"y_stagger={self.y_stagger}, "
-            f"x_stagger={self.x_stagger})"
-        )
+        return f"StaticField(shape={self._data.shape}, dtype={self.dtype}, layout={self.layout})"
 
     def __str__(self) -> str:
-        return f"StaticField on z={self.z_stagger.name}, y={self.y_stagger.name}, x={self.x_stagger.name} grid"
+        return f"StaticField on {self._data.layout} grid"
 
     @property
     def dtype(self) -> np.dtype:
@@ -193,21 +168,15 @@ class StaticField(Field):
         """Shape of the spatial dimensions of the field."""
         return self._data.shape
 
-    @property
-    def nspatial_dims(self) -> int:
-        """Number of spatial dimensions of the field."""
-        return len(self.spatial_shape)
-
-    def validate_shape(self, simulation_shape: tuple[int, int, int, int]) -> None:
-        """Validate that the field's shape is compatible with the domain shape."""
-        staggered_shape = (
-            self.z_stagger.expected_size(simulation_shape[1]),
-            self.y_stagger.expected_size(simulation_shape[2]),
-            self.x_stagger.expected_size(simulation_shape[3]),
-        )
-        expected_shape = tuple(s for s in staggered_shape if s is not None)
-        if self._data.shape != expected_shape:
-            raise ValueError(f"Expected shape {expected_shape} but data has shape {self._data.shape}")
+    def validate_shape(self, simulation_shape: SimulationSize) -> None:
+        """Validate that the field's shape is compatible with the simulation shape."""
+        for data_size, axis, stagger in zip(self._data.shape, self.axes, self.staggers):
+            simulation_axis_size = simulation_shape.axis_size(axis)
+            expected_size = stagger.expected_size(simulation_axis_size)
+            if data_size != expected_size:
+                raise ValueError(
+                    f"Expected size {expected_size} along axis {axis} but got {self._data.shape[axis.value]}"
+                )
 
     def get_field_data(self, time_index: float, bbox: BBox) -> FieldData:
         """Get the field data at a given time index.
@@ -224,7 +193,7 @@ class StaticField(Field):
         Returns
         -------
         FieldData
-            Namedtuple containing the field data array and offsets.
+            Dataclass containing the field data array and offsets.
         """
         # For static fields, we ignore time_index
         array, offsets = self._data.get_data_subset(bbox)
@@ -234,20 +203,18 @@ class StaticField(Field):
     def from_numpy(
         cls,
         data: npt.NDArray,
-        z_stagger: Stagger | str,
-        y_stagger: Stagger | str,
-        x_stagger: Stagger | str,
+        axes: tuple[ArrayAxis | str, ...],
+        staggers: tuple[Stagger | str, ...],
         *,
         attrs: dict[str, Any] | None = None,
     ) -> "StaticField":
         """Create a StaticField from a NumPy array."""
+        layout = ArrayLayout(axes, staggers)
         if not isinstance(data, np.ndarray):
             raise TypeError(f"Expected a NumPy array, got {type(data).__name__}")
         spatial_array = NumpyArray(
             data=data,
-            z_stagger=Stagger(z_stagger),
-            y_stagger=Stagger(y_stagger),
-            x_stagger=Stagger(x_stagger),
+            layout=layout,
         )
         return cls(data=spatial_array, attrs=attrs)
 
@@ -255,20 +222,18 @@ class StaticField(Field):
     def from_dask(
         cls,
         data: da.Array,
-        z_stagger: Stagger | str,
-        y_stagger: Stagger | str,
-        x_stagger: Stagger | str,
+        axes: tuple[ArrayAxis | str, ...],
+        staggers: tuple[Stagger | str, ...],
         *,
         attrs: dict[str, Any] | None = None,
     ) -> "StaticField":
         """Create a StaticField from a chunked Dask array."""
+        layout = ArrayLayout(axes, staggers)
         if not isinstance(data, da.Array):
             raise TypeError(f"Expected a Dask array, got {type(data).__name__}")
         spatial_array = ChunkedDaskArray(
             data=data,
-            z_stagger=Stagger(z_stagger),
-            y_stagger=Stagger(y_stagger),
-            x_stagger=Stagger(x_stagger),
+            layout=layout,
         )
         return cls(data=spatial_array, attrs=attrs)
 
@@ -276,9 +241,8 @@ class StaticField(Field):
     def from_arraylike(
         cls,
         data: npt.ArrayLike,
-        z_stagger: Stagger | str,
-        y_stagger: Stagger | str,
-        x_stagger: Stagger | str,
+        axes: tuple[ArrayAxis | str, ...],
+        staggers: tuple[Stagger | str, ...],
         *,
         attrs: dict[str, Any] | None = None,
     ) -> "StaticField":
@@ -296,14 +260,15 @@ class StaticField(Field):
                 "Use StaticField.from_dask for Dask arrays.",
                 stacklevel=2,
             )
-        return cls.from_numpy(np.asarray(data), z_stagger, y_stagger, x_stagger, attrs=attrs)
+        return cls.from_numpy(np.asarray(data), axes, staggers, attrs=attrs)
 
     @classmethod
     def from_xarray(
         cls,
         data: xr.DataArray,
-        dims: Mapping[str, tuple[ArrayAxis | str, Stagger | str]] | None = None,
-        **dims_kwargs: tuple[ArrayAxis | str, Stagger | str],
+        dims: Mapping[str, tuple[ArrayAxis | str, Stagger | str]],
+        *,
+        ignore_missing_dims: bool = False,
     ) -> "StaticField":
         """Create a StaticField from an xarray DataArray.
 
@@ -311,57 +276,54 @@ class StaticField(Field):
         ----------
         data : xr.DataArray
             The input xarray DataArray containing the field data.
-        dims : Mapping[str, tuple[ArrayAxis | str, Stagger | str]], optional
+        dims : Mapping[str, tuple[ArrayAxis | str, Stagger | str]]
             Mapping of dimension names to ``(ArrayAxis, Stagger)`` tuples.
-            Cannot be combined with keyword arguments.
-        **dims_kwargs : tuple[ArrayAxis | str, Stagger | str]
-            Dimension mappings as keyword arguments.
-            Cannot be combined with the ``dims`` positional mapping.
+        ignore_missing_dims : bool, optional
+            If True, dimensions specified in ``dims`` that are not present in the DataArray will
+            be ignored. If False (default), a ValueError will be raised.
+
 
         Returns
         -------
         StaticField
             A StaticField instance created from the input xarray DataArray.
 
-        Raises
-        ------
-        TypeError
-            If both ``dims`` and keyword arguments are provided.
-
         Notes
         -----
-        The dimension names provided in ``dims`` (or as keyword arguments) must
-        match the dimensions of ``data`` exactly.
+        The dimension names provided in ``dims`` must match the dimensions of ``data`` exactly unless
+        ``ignore_missing_dims`` is True, in which case extra dimensions in ``dims`` that are not present
+        in ``data`` will be ignored. All dimensions in ``data`` must be accounted for in ``dims``
+        regardless of the value of ``ignore_missing_dims``.
         """
-        if dims is not None and dims_kwargs:
-            raise TypeError("cannot specify both 'dims' and keyword arguments")
-        resolved_dims: Mapping[str, tuple[ArrayAxis | str, Stagger | str]] = dims if dims is not None else dims_kwargs
+        # build an array layout from the provided dims
+        dims_mapping = dims.copy()  # make a copy to avoid mutating the input
+        axes = []
+        staggers = []
+        for dim in data.dims:
+            if dim not in dims:
+                raise ValueError(f"Dimension '{dim}' in data is missing from dims mapping.")
+            axis, stagger = dims_mapping.pop(dim)
+            axes.append(ArrayAxis.parse(axis))
+            staggers.append(Stagger.parse(stagger))
 
-        # validate inputs
-        _validate_xarray_dims_match(data, resolved_dims)
+        # error if there are any extra dimensions in dims that were not in data
+        if (not ignore_missing_dims) and dims_mapping:
+            raise ValueError(f"Dimensions in dims mapping not found in data: {list(dims_mapping.keys())}")
 
-        # parse dims to get dimension names and staggers for each axis
-        z_dim, y_dim, x_dim = _parse_xarray_dims(resolved_dims)
-
-        # get the array in the correct order with invariant dimensions squeezed out
-        transformed_data = _transform_xarray_data_array(data, z_dim, y_dim, x_dim)
-        array = transformed_data.data
+        layout = ArrayLayout(axes, staggers)
+        array = data.data
 
         # create spatial array
         if isinstance(array, da.Array):
             return cls.from_dask(
                 data=array,
-                z_stagger=z_dim[1],
-                y_stagger=y_dim[1],
-                x_stagger=x_dim[1],
+                layout=layout,
                 attrs=data.attrs,
             )
         else:
             return cls.from_arraylike(
                 data=array,
-                z_stagger=z_dim[1],
-                y_stagger=y_dim[1],
-                x_stagger=x_dim[1],
+                layout=layout,
                 attrs=data.attrs,
             )
 
@@ -719,7 +681,7 @@ class TimeDependentField(Field):
         resolved_dims: Mapping[str, tuple[ArrayAxis | str, Stagger | str]] = dims if dims is not None else dims_kwargs
 
         # validate inputs (time dim presence + spatial dim correspondence)
-        _validate_xarray_dims_match(data, resolved_dims, time_dim=time_dim)
+        # _validate_xarray_dims_match(data, resolved_dims, time_dim=time_dim)
 
         # parse dims to get dimension names and staggers for each axis
         z_dim, y_dim, x_dim = _parse_xarray_dims(resolved_dims)
@@ -759,44 +721,6 @@ def _perform_interpolation(
     n = previous.size
     for i in numba.prange(n):  # ty: ignore[not-iterable]
         output[i] = previous[i] + ft * delta[i]
-
-
-def _validate_xarray_dims_match(
-    data: xr.DataArray,
-    dims: Mapping[str, tuple[ArrayAxis | str, Stagger | str]],
-    *,
-    time_dim: str | None = None,
-) -> None:
-    """Validate that the specified dimension mappings match the xarray DataArray.
-
-    Parameters
-    ----------
-    data : xr.DataArray
-        The input xarray DataArray containing the field data.
-    dims : Mapping[str, tuple[ArrayAxis | str, Stagger | str]]
-        Mapping of spatial dimension names to tuples of (ArrayAxis, Stagger).
-    time_dim : str | None, optional
-        Name of the time dimension in the DataArray.  When provided the
-        dimension must be present in ``data`` and is excluded from the
-        comparison against ``dims``.
-
-    Raises
-    ------
-    ValueError
-        If ``time_dim`` is given but not present in the DataArray, or if the
-        spatial dimension names in ``dims`` do not exactly match the
-        (non-time) dimensions in ``data``.
-    """
-    if time_dim is not None:
-        if time_dim not in data.dims:
-            raise ValueError(f"Time dimension '{time_dim}' not found in DataArray dimensions: {list(data.dims)}")
-        data_dims_set = set(data.dims) - {time_dim}
-    else:
-        data_dims_set = set(data.dims)
-
-    dims_keys_set = set(dims.keys())
-    if mismatch := (data_dims_set ^ dims_keys_set):
-        raise ValueError(f"Dimension names in dims must exactly match dimensions in data. Mismatch: {mismatch}")
 
 
 def _parse_xarray_dims(

--- a/src/offline_particles/fields.py
+++ b/src/offline_particles/fields.py
@@ -179,9 +179,7 @@ class StaticField(Field):
             simulation_axis_size = simulation_size.axis_size(axis)
             expected_size = stagger.expected_size(simulation_axis_size)
             if data_size != expected_size:
-                raise ValueError(
-                    f"Expected size {expected_size} along axis {axis} but got {data_size}"
-                )
+                raise ValueError(f"Expected size {expected_size} along axis {axis} but got {data_size}")
 
     def get_field_data(self, time_index: float, bbox: BBox) -> FieldData:
         """Get the field data at a given time index.
@@ -666,7 +664,7 @@ class TimeDependentField(Field):
         dims_mapping = dict(dims)  # make a copy to avoid mutating the input
         axes = []
         staggers = []
-        for dim in data.dims:
+        for dim in spatial_dims:
             if dim not in dims:
                 raise ValueError(f"Dimension '{dim}' in data is missing from dims mapping.")
             axis, stagger = dims_mapping.pop(dim)

--- a/src/offline_particles/fields.py
+++ b/src/offline_particles/fields.py
@@ -435,9 +435,7 @@ class TimeDependentField(Field):
             simulation_axis_size = simulation_size.axis_size(axis)
             expected_size = stagger.expected_size(simulation_axis_size)
             if data_size != expected_size:
-                raise ValueError(
-                    f"Expected size {expected_size} along axis {axis} but got {self._data.shape[axis.value]}"
-                )
+                raise ValueError(f"Expected size {expected_size} along axis {axis} but got {data_size}")
 
     @property
     def previous_time_slice(self) -> SpatialArray:

--- a/src/offline_particles/fields.py
+++ b/src/offline_particles/fields.py
@@ -68,22 +68,22 @@ class Field(abc.ABC):
     @property
     def ndim(self) -> int:
         """Number of dimensions in the spatial array."""
-        return self._layout.ndim
+        return self.layout.ndim
 
     @property
     def axes(self) -> tuple[ArrayAxis, ...]:
         """Axes of the spatial array."""
-        return self._layout.axes
+        return self.layout.axes
 
     @property
     def staggers(self) -> tuple[Stagger, ...]:
         """Staggering of the dimensions."""
-        return self._layout.staggers
+        return self.layout.staggers
 
     @property
-    def offsets(self) -> tuple[float]:
+    def offsets(self) -> tuple[float, ...]:
         """Offsets for all dimensions."""
-        return self._layout.offsets
+        return self.layout.offsets
 
     @property
     def attrs(self) -> dict[str, Any]:
@@ -114,8 +114,8 @@ class Field(abc.ABC):
         return self._layout.ndim
 
     @abc.abstractmethod
-    def validate_shape(self, simulation_shape: SimulationSize) -> None:
-        """Validate that the field's shape is compatible with the domain shape."""
+    def validate_shape(self, simulation_size: SimulationSize) -> None:
+        """Validate that the field's shape is compatible with the sizes of the simulation dimensions."""
         pass
 
     @abc.abstractmethod
@@ -173,10 +173,10 @@ class StaticField(Field):
         """Shape of the spatial dimensions of the field."""
         return self._data.shape
 
-    def validate_shape(self, simulation_shape: SimulationSize) -> None:
-        """Validate that the field's shape is compatible with the simulation shape."""
+    def validate_shape(self, simulation_size: SimulationSize) -> None:
+        """Validate that the field's shape is compatible with the sizes of the simulation dimensions."""
         for data_size, axis, stagger in zip(self._data.shape, self.axes, self.staggers):
-            simulation_axis_size = simulation_shape.axis_size(axis)
+            simulation_axis_size = simulation_size.axis_size(axis)
             expected_size = stagger.expected_size(simulation_axis_size)
             if data_size != expected_size:
                 raise ValueError(
@@ -301,7 +301,7 @@ class StaticField(Field):
         regardless of the value of ``ignore_missing_dims``.
         """
         # build an array layout from the provided dims
-        dims_mapping = dims.copy()  # make a copy to avoid mutating the input
+        dims_mapping = dict(dims)  # make a copy to avoid mutating the input
         axes = []
         staggers = []
         for dim in data.dims:
@@ -309,26 +309,27 @@ class StaticField(Field):
                 raise ValueError(f"Dimension '{dim}' in data is missing from dims mapping.")
             axis, stagger = dims_mapping.pop(dim)
             axes.append(ArrayAxis.parse(axis))
-            staggers.append(Stagger.parse(stagger))
+            staggers.append(Stagger(stagger))
 
         # error if there are any extra dimensions in dims that were not in data
         if (not ignore_missing_dims) and dims_mapping:
             raise ValueError(f"Dimensions in dims mapping not found in data: {list(dims_mapping.keys())}")
 
-        layout = ArrayLayout(axes, staggers)
         array = data.data
 
         # create spatial array
         if isinstance(array, da.Array):
             return cls.from_dask(
                 data=array,
-                layout=layout,
+                axes=tuple(axes),
+                staggers=tuple(staggers),
                 attrs=data.attrs,
             )
         else:
             return cls.from_arraylike(
                 data=array,
-                layout=layout,
+                axes=tuple(axes),
+                staggers=tuple(staggers),
                 attrs=data.attrs,
             )
 
@@ -425,17 +426,18 @@ class TimeDependentField(Field):
         """Number of spatial dimensions of the field."""
         return len(self.spatial_shape)
 
-    def validate_shape(self, simulation_shape: tuple[int, int, int, int]) -> None:
-        """Validate that the field's shape is compatible with the domain shape."""
-        staggered_shape = (
-            simulation_shape[0],
-            self.z_stagger.expected_size(simulation_shape[1]),
-            self.y_stagger.expected_size(simulation_shape[2]),
-            self.x_stagger.expected_size(simulation_shape[3]),
-        )
-        expected_shape = tuple(s for s in staggered_shape if s is not None)
-        if self._data.shape != expected_shape:
-            raise ValueError(f"Expected shape {expected_shape} but data has shape {self._data.shape}")
+    def validate_shape(self, simulation_size: SimulationSize) -> None:
+        """Validate that the field's shape is compatible with the sizes of the simulation dimensions."""
+        # first validate time dimension
+        if self._data.shape[0] != simulation_size.time:
+            raise ValueError(f"Expected size {simulation_size.time} along time axis but got {self._data.shape[0]}")
+        for data_size, axis, stagger in zip(self._data.shape[1:], self.axes, self.staggers):
+            simulation_axis_size = simulation_size.axis_size(axis)
+            expected_size = stagger.expected_size(simulation_axis_size)
+            if data_size != expected_size:
+                raise ValueError(
+                    f"Expected size {expected_size} along axis {axis} but got {self._data.shape[axis.value]}"
+                )
 
     @property
     def previous_time_slice(self) -> SpatialArray:
@@ -663,7 +665,7 @@ class TimeDependentField(Field):
         data = data.transpose([time_dim] + spatial_dims)
 
         # build an array layout from the provided dims
-        dims_mapping = dims.copy()  # make a copy to avoid mutating the input
+        dims_mapping = dict(dims)  # make a copy to avoid mutating the input
         axes = []
         staggers = []
         for dim in data.dims:
@@ -671,26 +673,27 @@ class TimeDependentField(Field):
                 raise ValueError(f"Dimension '{dim}' in data is missing from dims mapping.")
             axis, stagger = dims_mapping.pop(dim)
             axes.append(ArrayAxis.parse(axis))
-            staggers.append(Stagger.parse(stagger))
+            staggers.append(Stagger(stagger))
 
         # error if there are any extra dimensions in dims that were not in data
         if (not ignore_missing_dims) and dims_mapping:
             raise ValueError(f"Dimensions in dims mapping not found in data: {list(dims_mapping.keys())}")
 
-        layout = ArrayLayout(axes, staggers)
         array = data.data
 
         # create field
         if isinstance(array, da.Array):
             return cls.from_dask(
                 data=array,
-                layout=layout,
+                axes=tuple(axes),
+                staggers=tuple(staggers),
                 attrs=data.attrs,
             )
         else:
             return cls.from_arraylike(
                 data=array,
-                layout=layout,
+                axes=tuple(axes),
+                staggers=tuple(staggers),
                 attrs=data.attrs,
             )
 

--- a/src/offline_particles/fields.py
+++ b/src/offline_particles/fields.py
@@ -658,7 +658,7 @@ class TimeDependentField(Field):
         spatial_dims = [dim for dim in data.dims if dim != time_dim]
 
         # move time dim to the front if it's not already
-        data = data.transpose([time_dim] + spatial_dims)
+        data = data.transpose(time_dim, *spatial_dims)
 
         # build an array layout from the provided dims
         dims_mapping = dict(dims)  # make a copy to avoid mutating the input

--- a/src/offline_particles/fields.py
+++ b/src/offline_particles/fields.py
@@ -180,7 +180,7 @@ class StaticField(Field):
             expected_size = stagger.expected_size(simulation_axis_size)
             if data_size != expected_size:
                 raise ValueError(
-                    f"Expected size {expected_size} along axis {axis} but got {self._data.shape[axis.value]}"
+                    f"Expected size {expected_size} along axis {axis} but got {data_size}"
                 )
 
     def get_field_data(self, time_index: float, bbox: BBox) -> FieldData:

--- a/src/offline_particles/fields.py
+++ b/src/offline_particles/fields.py
@@ -61,6 +61,11 @@ class Field(abc.ABC):
         self._attrs = attrs
 
     @property
+    def layout(self) -> ArrayLayout:
+        """The array layout of the field."""
+        return self._layout
+
+    @property
     def ndim(self) -> int:
         """Number of dimensions in the spatial array."""
         return self._layout.ndim
@@ -337,18 +342,14 @@ class TimeDependentField(Field):
     def __init__(
         self,
         data: da.Array | npt.NDArray,
-        z_stagger: Stagger | str,
-        y_stagger: Stagger | str,
-        x_stagger: Stagger | str,
+        layout: ArrayLayout,
         spatial_array_factory: SpatialArrayFactory = NumpyArray,
         output_dtype: npt.DTypeLike = np.float64,
         *,
         attrs: dict[str, Any] | None = None,
     ):
         super().__init__(
-            z_stagger=Stagger(z_stagger),
-            y_stagger=Stagger(y_stagger),
-            x_stagger=Stagger(x_stagger),
+            layout=layout,
             attrs=attrs,
         )
 
@@ -377,12 +378,8 @@ class TimeDependentField(Field):
             raise ValueError("TimeDependentField requires at least 2 time steps.")
         self._num_timesteps = self._data.shape[0]
         self._It = 0
-        self._previous_time_slice = self._spatial_array_factory(
-            self._data[0, ...], self.z_stagger, self.y_stagger, self.x_stagger
-        )
-        self._next_time_slice = self._spatial_array_factory(
-            self._data[1, ...], self.z_stagger, self.y_stagger, self.x_stagger
-        )
+        self._previous_time_slice = self._spatial_array_factory(self._data[0, ...], self.layout)
+        self._next_time_slice = self._spatial_array_factory(self._data[1, ...], self.layout)
 
     def _allocate_interpolation_arrays(self, shape: tuple[int, ...]) -> None:
         """Allocate temporary arrays for interpolation."""
@@ -400,14 +397,13 @@ class TimeDependentField(Field):
     def __repr__(self) -> str:
         return (
             f"TimeDependentField(shape={self._data.shape}, "
-            f"z_stagger={self.z_stagger}, "
-            f"y_stagger={self.y_stagger}, "
-            f"x_stagger={self.x_stagger}, "
+            f"dtype={self._data.dtype}, "
+            f"layout={self.layout}, "
             f"spatial_array_factory={self._spatial_array_factory.__name__})"
         )
 
     def __str__(self) -> str:
-        return f"TimeDependentField on z={self.z_stagger.name}, y={self.y_stagger.name}, x={self.x_stagger.name} grid"
+        return f"TimeDependentField on {self.layout} grid"
 
     @property
     def dtype(self) -> np.dtype:
@@ -458,12 +454,7 @@ class TimeDependentField(Field):
             raise IndexError("Cannot increment past the penultimate timestep.")
         self._It += 1
         self._previous_time_slice = self._next_time_slice
-        self._next_time_slice = self._spatial_array_factory(
-            self._data[self._It + 1, ...],
-            self.z_stagger,
-            self.y_stagger,
-            self.x_stagger,
-        )
+        self._next_time_slice = self._spatial_array_factory(self._data[self._It + 1, ...], self.layout)
         # loading new data invalidates cached delta and output
         self._cached_delta_valid = False
         self._output_valid = False
@@ -475,12 +466,7 @@ class TimeDependentField(Field):
             raise IndexError("Cannot decrement past the first timestep.")
         self._It -= 1
         self._next_time_slice = self._previous_time_slice
-        self._previous_time_slice = self._spatial_array_factory(
-            self._data[self._It, ...],
-            self.z_stagger,
-            self.y_stagger,
-            self.x_stagger,
-        )
+        self._previous_time_slice = self._spatial_array_factory(self._data[self._It, ...], self.layout)
         # loading new data invalidates cached delta and output
         self._cached_delta_valid = False
         self._output_valid = False
@@ -501,15 +487,8 @@ class TimeDependentField(Field):
             raise IndexError(f"Valid range of time indices is 0,...,{self._num_timesteps - 2}, got {It}.")
 
         self._It = It
-        self._previous_time_slice = self._spatial_array_factory(
-            self._data[self._It, ...], self.z_stagger, self.y_stagger, self.x_stagger
-        )
-        self._next_time_slice = self._spatial_array_factory(
-            self._data[self._It + 1, ...],
-            self.z_stagger,
-            self.y_stagger,
-            self.x_stagger,
-        )
+        self._previous_time_slice = self._spatial_array_factory(self._data[self._It, ...], self.layout)
+        self._next_time_slice = self._spatial_array_factory(self._data[self._It + 1, ...], self.layout)
         # loading new data invalidates cached delta and output
         self._cached_delta_valid = False
         self._output_valid = False
@@ -581,44 +560,43 @@ class TimeDependentField(Field):
     def from_numpy(
         cls,
         data: npt.NDArray,
-        z_stagger: Stagger | str,
-        y_stagger: Stagger | str,
-        x_stagger: Stagger | str,
+        axes: tuple[ArrayAxis | str, ...],
+        staggers: tuple[Stagger | str, ...],
         *,
         attrs: dict[str, Any] | None = None,
     ) -> "TimeDependentField":
         """Create a TimeDependentField from a NumPy array."""
+        layout = ArrayLayout(axes, staggers)
         if not isinstance(data, np.ndarray):
             raise TypeError(f"Expected a NumPy array, got {type(data).__name__}")
-        return cls(data, z_stagger, y_stagger, x_stagger, NumpyArray, attrs=attrs)
+        return cls(data, layout, NumpyArray, attrs=attrs)
 
     @classmethod
     def from_dask(
         cls,
         data: da.Array,
-        z_stagger: Stagger | str,
-        y_stagger: Stagger | str,
-        x_stagger: Stagger | str,
+        axes: tuple[ArrayAxis | str, ...],
+        staggers: tuple[Stagger | str, ...],
         *,
         preload_space: bool = False,
         attrs: dict[str, Any] | None = None,
     ) -> "TimeDependentField":
         """Create a TimeDependentField from a chunked Dask array."""
+        layout = ArrayLayout(axes, staggers)
         if not isinstance(data, da.Array):
             raise TypeError(f"Expected a Dask array, got {type(data).__name__}")
         if preload_space:
             factory = NumpyArray
         else:
             factory = ChunkedDaskArray
-        return cls(data, z_stagger, y_stagger, x_stagger, factory, attrs=attrs)
+        return cls(data, layout, factory, attrs=attrs)
 
     @classmethod
     def from_arraylike(
         cls,
         data: npt.ArrayLike,
-        z_stagger: Stagger | str,
-        y_stagger: Stagger | str,
-        x_stagger: Stagger | str,
+        axes: tuple[ArrayAxis | str, ...],
+        staggers: tuple[Stagger | str, ...],
         *,
         attrs: dict[str, Any] | None = None,
     ) -> "TimeDependentField":
@@ -636,15 +614,16 @@ class TimeDependentField(Field):
                 "Use TimeDependentField.from_dask for Dask arrays.",
                 stacklevel=2,
             )
-        return cls.from_numpy(np.asarray(data), z_stagger, y_stagger, x_stagger, attrs=attrs)
+        return cls.from_numpy(np.asarray(data), axes, staggers, attrs=attrs)
 
     @classmethod
     def from_xarray(
         cls,
         data: xr.DataArray,
         time_dim: str,
-        dims: Mapping[str, tuple[ArrayAxis | str, Stagger | str]] | None = None,
-        **dims_kwargs: tuple[ArrayAxis | str, Stagger | str],
+        dims: Mapping[str, tuple[ArrayAxis | str, Stagger | str]],
+        *,
+        ignore_missing_dims: bool = False,
     ) -> "TimeDependentField":
         """Create a TimeDependentField from an xarray DataArray.
 
@@ -654,57 +633,64 @@ class TimeDependentField(Field):
             The input xarray DataArray containing the field data.
         time_dim : str
             Name of the time dimension in the DataArray.
-        dims : Mapping[str, tuple[ArrayAxis | str, Stagger | str]], optional
+        dims : Mapping[str, tuple[ArrayAxis | str, Stagger | str]]
             Mapping of spatial dimension names to ``(ArrayAxis, Stagger)`` tuples.
             Cannot be combined with keyword arguments.
-        **dims_kwargs : tuple[ArrayAxis | str, Stagger | str]
-            Spatial dimension mappings as keyword arguments.
-            Cannot be combined with the ``dims`` positional mapping.
+        ignore_missing_dims : bool, optional
+            If True, dimensions specified in ``dims`` that are not present in the DataArray will
+            be ignored. If False (default), a ValueError will be raised.
 
         Returns
         -------
         TimeDependentField
             A TimeDependentField instance created from the input xarray DataArray.
 
-        Raises
-        ------
-        TypeError
-            If both ``dims`` and keyword arguments are provided.
-
         Notes
         -----
         The spatial dimension names in ``dims`` (or keyword arguments) must exactly
-        match all non-time dimensions in ``data``.
+        match all non-time dimensions in ``data`` unless ``ignore_missing_dims`` is True, in which case extra dimensions in ``dims``
+        that are not present in ``data`` will be ignored. All non-time dimensions in ``data`` must be accounted for in ``dims``
+        regardless of the value of ``ignore_missing_dims``.
         """
-        if dims is not None and dims_kwargs:
-            raise TypeError("cannot specify both 'dims' and keyword arguments")
-        resolved_dims: Mapping[str, tuple[ArrayAxis | str, Stagger | str]] = dims if dims is not None else dims_kwargs
+        # first ensure time dim exists
+        if time_dim not in data.dims:
+            raise ValueError(f"Time dimension '{time_dim}' not found in data dimensions {data.dims}")
 
-        # validate inputs (time dim presence + spatial dim correspondence)
-        # _validate_xarray_dims_match(data, resolved_dims, time_dim=time_dim)
+        # get spatial dims on data
+        spatial_dims = [dim for dim in data.dims if dim != time_dim]
 
-        # parse dims to get dimension names and staggers for each axis
-        z_dim, y_dim, x_dim = _parse_xarray_dims(resolved_dims)
+        # move time dim to the front if it's not already
+        data = data.transpose([time_dim] + spatial_dims)
 
-        # get the array in the correct order with invariant dimensions squeezed out
-        transformed_data = _transform_xarray_data_array(data, z_dim, y_dim, x_dim, time_dim=time_dim)
-        array = transformed_data.data
+        # build an array layout from the provided dims
+        dims_mapping = dims.copy()  # make a copy to avoid mutating the input
+        axes = []
+        staggers = []
+        for dim in data.dims:
+            if dim not in dims:
+                raise ValueError(f"Dimension '{dim}' in data is missing from dims mapping.")
+            axis, stagger = dims_mapping.pop(dim)
+            axes.append(ArrayAxis.parse(axis))
+            staggers.append(Stagger.parse(stagger))
+
+        # error if there are any extra dimensions in dims that were not in data
+        if (not ignore_missing_dims) and dims_mapping:
+            raise ValueError(f"Dimensions in dims mapping not found in data: {list(dims_mapping.keys())}")
+
+        layout = ArrayLayout(axes, staggers)
+        array = data.data
 
         # create field
         if isinstance(array, da.Array):
             return cls.from_dask(
                 data=array,
-                z_stagger=z_dim[1],
-                y_stagger=y_dim[1],
-                x_stagger=x_dim[1],
+                layout=layout,
                 attrs=data.attrs,
             )
         else:
             return cls.from_arraylike(
                 data=array,
-                z_stagger=z_dim[1],
-                y_stagger=y_dim[1],
-                x_stagger=x_dim[1],
+                layout=layout,
                 attrs=data.attrs,
             )
 
@@ -721,89 +707,3 @@ def _perform_interpolation(
     n = previous.size
     for i in numba.prange(n):  # ty: ignore[not-iterable]
         output[i] = previous[i] + ft * delta[i]
-
-
-def _parse_xarray_dims(
-    dims: Mapping[str, tuple[ArrayAxis | str, Stagger | str]],
-) -> tuple[tuple[str | None, Stagger], tuple[str | None, Stagger], tuple[str | None, Stagger]]:
-    """Parse the dimension mappings and validate the stagger values.
-
-    Parameters
-    ----------
-    dims : Mapping[str, tuple[ArrayAxis | str, Stagger | str]]
-        Mapping of dimension names to tuples of (ArrayAxis, Stagger).
-
-    Raises
-    ------
-    ValueError
-        If any of the stagger values are invalid.
-    """
-    # first convert to ArrayAxis and Stagger enums
-    parsed_dims: dict[str, tuple[ArrayAxis, Stagger]] = {
-        dim: (ArrayAxis.parse(axis), Stagger(stagger)) for dim, (axis, stagger) in dims.items()
-    }
-
-    # extract the dimension names and staggers for each axis, ensuring no duplicates
-    z_dim = _extract_dim(ArrayAxis.Z, parsed_dims)
-    y_dim = _extract_dim(ArrayAxis.Y, parsed_dims)
-    x_dim = _extract_dim(ArrayAxis.X, parsed_dims)
-
-    return z_dim, y_dim, x_dim
-
-
-def _extract_dim(axis: ArrayAxis, dims: dict[str, tuple[ArrayAxis, Stagger]]) -> tuple[str | None, Stagger]:
-    """Extract the dimension name and stagger for a given axis.
-
-    Parameters
-    ----------
-    axis : ArrayAxis
-        The axis to extract (Z, Y, or X).
-    dims : dict[str, tuple[ArrayAxis, Stagger]]
-        Mapping of dimension names to tuples of (ArrayAxis, Stagger).
-
-    Returns
-    -------
-    tuple[str | None, Stagger]
-        The dimension name and stagger for the specified axis. If no dimension is mapped to the axis, returns (None, Stagger.INVARIANT).
-
-    Raises
-    ------
-    ValueError
-        If multiple dimensions are mapped to the same axis.
-    """
-    matching_dims = [(dim, stagger) for dim, (ax, stagger) in dims.items() if ax == axis]
-    if len(matching_dims) == 0:
-        return None, Stagger.INVARIANT
-    elif len(matching_dims) == 1:
-        return matching_dims[0]
-    else:
-        raise ValueError(f"Multiple dimensions mapped to {axis} axis: {matching_dims}")
-
-
-def _transform_xarray_data_array(
-    data: xr.DataArray,
-    z_dim: tuple[str | None, Stagger],
-    y_dim: tuple[str | None, Stagger],
-    x_dim: tuple[str | None, Stagger],
-    time_dim: str | None = None,
-) -> xr.DataArray:
-    """Transform the DataArray by transposing and squeezing dimensions as needed."""
-    # time goes first if present
-    dims_in_order = []
-    if time_dim is not None:
-        dims_in_order.append(time_dim)
-
-    # add active dimensions and squeeze invariant dimensions
-    for dim_name, stagger in (z_dim, y_dim, x_dim):
-        if dim_name is None:
-            continue
-        if stagger.is_active:
-            dims_in_order.append(dim_name)
-        else:
-            if data.sizes[dim_name] != 1:
-                raise ValueError(
-                    f"Dimension '{dim_name}' is marked as invariant but has size {data.sizes[dim_name]} != 1"
-                )
-            data = data.squeeze(dim=dim_name)
-
-    return data.transpose(*dims_in_order)

--- a/src/offline_particles/fieldset.py
+++ b/src/offline_particles/fieldset.py
@@ -5,7 +5,7 @@ from typing import Any, ItemsView, KeysView, Mapping, ValuesView
 
 import numpy as np
 
-from .fields import Field
+from .fields import Field, SimulationSize
 
 
 class Fieldset:
@@ -18,8 +18,11 @@ class Fieldset:
         z_size: size of the centered z dimension
         y_size: size of the centered y dimension
         x_size: size of the centered x dimension
-        constants: optional keyword argument, dictionary of constants to add to the fieldset
-        fields: fields to add to the fieldset as keyword arguments
+        fields: optional dictionary of fields to add to the fieldset
+        constants: optional dictionary of constants to add to the fieldset
+        zidx_bounds: optional bounds of the z index (default: (0, z_size - 1))
+        yidx_bounds: optional bounds of the y index (default: (0, y_size - 1))
+        xidx_bounds: optional bounds of the x index (default: (0, x_size - 1))
     """
 
     def __init__(
@@ -29,32 +32,34 @@ class Fieldset:
         y_size: int,
         x_size: int,
         *,
+        fields: Mapping[str, Field] | None = None,
         constants: Mapping[str, Any] | None = None,
         zidx_bounds: tuple[float, float] | None = None,
         yidx_bounds: tuple[float, float] | None = None,
         xidx_bounds: tuple[float, float] | None = None,
-        **fields: Field,
     ) -> None:
         super().__init__()
         # sizes of centered dimensions
-        self._t_size = t_size
-        self._z_size = z_size
-        self._y_size = y_size
-        self._x_size = x_size
+        self._simulation_size = SimulationSize(t_size=t_size, z_size=z_size, y_size=y_size, x_size=x_size)
 
         # set default index bounds if not provided
         if zidx_bounds is None:
-            zidx_bounds = (0, z_size - 1)
+            zidx_bounds = (0, self._simulation_size.z - 1)
         if yidx_bounds is None:
-            yidx_bounds = (0, y_size - 1)
+            yidx_bounds = (0, self._simulation_size.y - 1)
         if xidx_bounds is None:
-            xidx_bounds = (0, x_size - 1)
+            xidx_bounds = (0, self._simulation_size.x - 1)
         self._zidx_bounds = (np.float64(zidx_bounds[0]), np.float64(zidx_bounds[1]))
         self._yidx_bounds = (np.float64(yidx_bounds[0]), np.float64(yidx_bounds[1]))
         self._xidx_bounds = (np.float64(xidx_bounds[0]), np.float64(xidx_bounds[1]))
 
         self._fields: dict[str, Field] = {}
         self._constants: dict[str, np.generic] = {}
+
+        # add fields
+        if fields is not None:
+            for name, field in fields.items():
+                self.add_field(name, field)
 
         # add constants
         if constants is not None:
@@ -69,29 +74,30 @@ class Fieldset:
         self.add_constant("xidx_min", self._xidx_bounds[0])
         self.add_constant("xidx_max", self._xidx_bounds[1])
 
-        # add fields
-        for name, field in fields.items():
-            self.add_field(name, field)
+    @property
+    def simulation_size(self) -> SimulationSize:
+        """Simulation size as a SimulationSize named tuple."""
+        return self._simulation_size
 
     @property
     def t_size(self) -> int:
         """Size of the time dimension."""
-        return self._t_size
+        return self.simulation_size.t
 
     @property
     def z_size(self) -> int:
         """Size of the centered z dimension."""
-        return self._z_size
+        return self.simulation_size.z
 
     @property
     def y_size(self) -> int:
         """Size of the centered y dimension."""
-        return self._y_size
+        return self.simulation_size.y
 
     @property
     def x_size(self) -> int:
         """Size of the centered x dimension."""
-        return self._x_size
+        return self.simulation_size.x
 
     @property
     def zidx_bounds(self) -> tuple[float, float]:
@@ -137,11 +143,6 @@ class Fieldset:
     def xidx_max(self) -> float:
         """Maximum x index."""
         return self._xidx_bounds[1]
-
-    @property
-    def simulation_shape(self) -> tuple[int, int, int, int]:
-        """4D shape of the simulation assuming centered grids."""
-        return (self._t_size, self._z_size, self._y_size, self._x_size)
 
     @property
     def fields(self) -> Mapping[str, Field]:

--- a/src/offline_particles/fieldset.py
+++ b/src/offline_particles/fieldset.py
@@ -40,7 +40,7 @@ class Fieldset:
     ) -> None:
         super().__init__()
         # sizes of centered dimensions
-        self._simulation_size = SimulationSize(t_size=t_size, z_size=z_size, y_size=y_size, x_size=x_size)
+        self._simulation_size = SimulationSize(time=t_size, z=z_size, y=y_size, x=x_size)
 
         # set default index bounds if not provided
         if zidx_bounds is None:
@@ -82,7 +82,7 @@ class Fieldset:
     @property
     def t_size(self) -> int:
         """Size of the time dimension."""
-        return self.simulation_size.t
+        return self.simulation_size.time
 
     @property
     def z_size(self) -> int:
@@ -163,7 +163,7 @@ class Fieldset:
         if name in self:
             raise KeyError(f"Field '{name}' already exists in Fieldset. First remove it before adding a new one.")
         try:
-            field.validate_shape(self.simulation_shape)
+            field.validate_shape(self.simulation_size)
         except ValueError as e:
             raise ValueError(f"Error validating shape of Field '{name}'.") from e
         self._fields[name] = field

--- a/src/offline_particles/kernels/__init__.py
+++ b/src/offline_particles/kernels/__init__.py
@@ -17,7 +17,7 @@ Types
      - ``Callable[[ParticlePropertiesType, ScalarsType, FieldDataType], None]``
 """
 
-from . import common_inputs, roms, status, timed_activation, timestepping, validation
+from . import input_declarations, layout_validators, roms, status, timed_activation, timestepping, validation
 from ._kernels import (
     BoundKernel,
     FieldDataDeclaration,
@@ -34,7 +34,8 @@ from .status import Status, is_active, is_inactive
 from .validation import construct_validation_kernel
 
 __all__ = [
-    "common_inputs",
+    "input_declarations",
+    "layout_validators",
     "roms",
     "status",
     "timed_activation",

--- a/src/offline_particles/kernels/_kernels.py
+++ b/src/offline_particles/kernels/_kernels.py
@@ -10,7 +10,7 @@ import numpy as np
 import numpy.typing as npt
 
 from ..fields import Field, FieldData
-from ..spatial_arrays import ALL_STAGGERS, Stagger
+from ..spatial_arrays import ArrayLayout
 
 # these type aliases are manually documented in the module docstring for better formatting in the docs,
 # if they are updated here, also update the docstring at the top of the __init__.py file
@@ -18,6 +18,8 @@ type ParticlePropertiesType = Mapping[str, npt.NDArray]
 type ScalarsType = Mapping[str, np.generic]
 type FieldDataType = Mapping[str, FieldData]
 type KernelFunction = Callable[[ParticlePropertiesType, ScalarsType, FieldDataType], None]
+
+type LayoutValidator = Callable[[ArrayLayout], None]
 
 
 @dataclasses.dataclass(frozen=True, slots=True, init=False)
@@ -48,23 +50,16 @@ class ScalarDeclaration(KernelInputDeclaration):
 class FieldDataDeclaration(KernelInputDeclaration):
     """Declaration of field data required by a kernel."""
 
-    z_staggers: frozenset[Stagger]
-    y_staggers: frozenset[Stagger]
-    x_staggers: frozenset[Stagger]
+    _layout_validators: tuple[LayoutValidator, ...]
 
     def __init__(
         self,
         name: str,
         dtype: npt.DTypeLike,
-        *,
-        z_staggers: Iterable[Stagger] = ALL_STAGGERS,
-        y_staggers: Iterable[Stagger] = ALL_STAGGERS,
-        x_staggers: Iterable[Stagger] = ALL_STAGGERS,
+        layout_validators: Iterable[LayoutValidator] = (),
     ) -> None:
-        KernelInputDeclaration.__init__(self, name, dtype)
-        object.__setattr__(self, "z_staggers", frozenset(Stagger(s) for s in z_staggers))
-        object.__setattr__(self, "y_staggers", frozenset(Stagger(s) for s in y_staggers))
-        object.__setattr__(self, "x_staggers", frozenset(Stagger(s) for s in x_staggers))
+        super().__init__(name, dtype)
+        object.__setattr__(self, "_layout_validators", tuple(layout_validators))
 
     def validate_field(self, field: Field) -> None:
         """Validate that a field matches this declaration."""
@@ -72,33 +67,12 @@ class FieldDataDeclaration(KernelInputDeclaration):
             raise TypeError(
                 f"Kernel field data '{self.name}' has dtype '{self.dtype}', but field has dtype '{field.output_dtype}'."
             )
-        if field.z_stagger not in self.z_staggers:
-            raise ValueError(
-                f"Valid z_staggers for kernel field data '{self.name}' are "
-                f"{self.z_staggers}, "
-                f"but field has z_stagger '{field.z_stagger}'."
-            )
-        if field.y_stagger not in self.y_staggers:
-            raise ValueError(
-                f"Valid y_staggers for kernel field data '{self.name}' are "
-                f"{self.y_staggers}, "
-                f"but field has y_stagger '{field.y_stagger}'."
-            )
-        if field.x_stagger not in self.x_staggers:
-            raise ValueError(
-                f"Valid x_staggers for kernel field data '{self.name}' are "
-                f"{self.x_staggers}, "
-                f"but field has x_stagger '{field.x_stagger}'."
-            )
+        for validator in self._layout_validators:
+            validator(field.layout)
 
     @property
     def _doc_string_part(self) -> str:
-        return (
-            f"'{self.name}' ({self.dtype})\n"
-            f"    z_staggers={self.z_staggers}\n"
-            f"    y_staggers={self.y_staggers}\n"
-            f"    x_staggers={self.x_staggers}"
-        )
+        return f"'{self.name}' ({self.dtype}) with {len(self._layout_validators)} layout validators"
 
 
 class ParticleKernel:

--- a/src/offline_particles/kernels/_kernels.py
+++ b/src/offline_particles/kernels/_kernels.py
@@ -58,7 +58,7 @@ class FieldDataDeclaration(KernelInputDeclaration):
         dtype: npt.DTypeLike,
         layout_validators: Iterable[LayoutValidator] = (),
     ) -> None:
-        super().__init__(name, dtype)
+        KernelInputDeclaration.__init__(self, name, dtype)
         object.__setattr__(self, "_layout_validators", tuple(layout_validators))
 
     def validate_field(self, field: Field) -> None:

--- a/src/offline_particles/kernels/base/__init__.py
+++ b/src/offline_particles/kernels/base/__init__.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from .._kernels import BoundKernel, ParticleKernel, ParticlePropertyDeclaration
-from ..common_inputs import STATUS_DECLARATION
+from ..input_declarations import STATUS_DECLARATION
 from ._base import (
     add_property,
     copy_property,

--- a/src/offline_particles/kernels/buoyancy/__init__.py
+++ b/src/offline_particles/kernels/buoyancy/__init__.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 
-from ...spatial_arrays import ACTIVE_STAGGERS
 from .._kernels import (
     BoundKernel,
     FieldDataDeclaration,
@@ -10,16 +9,20 @@ from .._kernels import (
     ParticlePropertyDeclaration,
     ScalarDeclaration,
 )
-from ..common_inputs import STATUS_DECLARATION, XIDX_DECLARATION, YIDX_DECLARATION, ZIDX_DECLARATION
+from ..input_declarations import (
+    STATUS_DECLARATION,
+    XIDX_DECLARATION,
+    YIDX_DECLARATION,
+    ZIDX_DECLARATION,
+)
+from ..layout_validators import validate_ZYX_ordering
 from ._buoyancy_force import buoyancy_force_accumulation
 
 rhs_declaration = ParticlePropertyDeclaration("rhs", np.float64)
 rho_property_declaration = ParticlePropertyDeclaration("rho", np.float64)
 rho0_declaration = ScalarDeclaration("rho0", np.float64)
 g_declaration = ScalarDeclaration("g", np.float64)
-rho_field_declaration = FieldDataDeclaration(
-    "rho", np.float64, z_staggers=ACTIVE_STAGGERS, y_staggers=ACTIVE_STAGGERS, x_staggers=ACTIVE_STAGGERS
-)
+rho_field_declaration = FieldDataDeclaration("rho", np.float64, [validate_ZYX_ordering])
 
 
 def construct_buoyancy_force_accumulation_kernel(

--- a/src/offline_particles/kernels/input_declarations.py
+++ b/src/offline_particles/kernels/input_declarations.py
@@ -24,6 +24,3 @@ def construct_time_declaration(time_dtype: npt.DTypeLike) -> ScalarDeclaration:
             the simulation clock's time array, e.g. np.dtype('datetime64[ns]').
     """
     return ScalarDeclaration("_time", np.dtype(time_dtype))
-
-
-# field data

--- a/src/offline_particles/kernels/interpolation/linear.py
+++ b/src/offline_particles/kernels/interpolation/linear.py
@@ -4,9 +4,17 @@ from typing import Literal
 
 import numpy as np
 
-from ...spatial_arrays import ACTIVE_STAGGERS, INACTIVE_STAGGERS
 from .._kernels import BoundKernel, FieldDataDeclaration, ParticleKernel, ParticlePropertyDeclaration
-from ..common_inputs import STATUS_DECLARATION, XIDX_DECLARATION, YIDX_DECLARATION, ZIDX_DECLARATION
+from ..input_declarations import STATUS_DECLARATION, XIDX_DECLARATION, YIDX_DECLARATION, ZIDX_DECLARATION
+from ..layout_validators import (
+    validate_X_ordering,
+    validate_Y_ordering,
+    validate_YX_ordering,
+    validate_Z_ordering,
+    validate_ZX_ordering,
+    validate_ZY_ordering,
+    validate_ZYX_ordering,
+)
 from ._linear import (
     bilinear_interpolation_accumulation_kernel_function,
     bilinear_interpolation_kernel_function,
@@ -27,25 +35,17 @@ __all__ = [
 output_declaration = ParticlePropertyDeclaration("output", np.float64)
 field_data_declarations_1d = {
     "zidx": FieldDataDeclaration(
-        "field", np.float64, z_staggers=ACTIVE_STAGGERS, y_staggers=INACTIVE_STAGGERS, x_staggers=INACTIVE_STAGGERS
+        "field",
+        np.float64,
+        [validate_Z_ordering],
     ),
-    "yidx": FieldDataDeclaration(
-        "field", np.float64, z_staggers=INACTIVE_STAGGERS, y_staggers=ACTIVE_STAGGERS, x_staggers=INACTIVE_STAGGERS
-    ),
-    "xidx": FieldDataDeclaration(
-        "field", np.float64, z_staggers=INACTIVE_STAGGERS, y_staggers=INACTIVE_STAGGERS, x_staggers=ACTIVE_STAGGERS
-    ),
+    "yidx": FieldDataDeclaration("field", np.float64, [validate_Y_ordering]),
+    "xidx": FieldDataDeclaration("field", np.float64, [validate_X_ordering]),
 }
 field_data_declarations_2d = {
-    ("zidx", "yidx"): FieldDataDeclaration(
-        "field", np.float64, z_staggers=ACTIVE_STAGGERS, y_staggers=ACTIVE_STAGGERS, x_staggers=INACTIVE_STAGGERS
-    ),
-    ("zidx", "xidx"): FieldDataDeclaration(
-        "field", np.float64, z_staggers=ACTIVE_STAGGERS, y_staggers=INACTIVE_STAGGERS, x_staggers=ACTIVE_STAGGERS
-    ),
-    ("yidx", "xidx"): FieldDataDeclaration(
-        "field", np.float64, z_staggers=INACTIVE_STAGGERS, y_staggers=ACTIVE_STAGGERS, x_staggers=ACTIVE_STAGGERS
-    ),
+    ("zidx", "yidx"): FieldDataDeclaration("field", np.float64, [validate_ZY_ordering]),
+    ("zidx", "xidx"): FieldDataDeclaration("field", np.float64, [validate_ZX_ordering]),
+    ("yidx", "xidx"): FieldDataDeclaration("field", np.float64, [validate_YX_ordering]),
 }
 
 
@@ -89,9 +89,7 @@ def _trilinear_interpolation_kernel() -> ParticleKernel:
             output_declaration,
         ],
         field_data=[
-            FieldDataDeclaration(
-                "field", np.float64, z_staggers=ACTIVE_STAGGERS, y_staggers=ACTIVE_STAGGERS, x_staggers=ACTIVE_STAGGERS
-            ),
+            FieldDataDeclaration("field", np.float64, [validate_ZYX_ordering]),
         ],
     )
 
@@ -136,9 +134,7 @@ def _trilinear_interpolation_accumulation_kernel() -> ParticleKernel:
             output_declaration,
         ],
         field_data=[
-            FieldDataDeclaration(
-                "field", np.float64, z_staggers=ACTIVE_STAGGERS, y_staggers=ACTIVE_STAGGERS, x_staggers=ACTIVE_STAGGERS
-            ),
+            FieldDataDeclaration("field", np.float64, [validate_ZYX_ordering]),
         ],
     )
 

--- a/src/offline_particles/kernels/layout_validators.py
+++ b/src/offline_particles/kernels/layout_validators.py
@@ -1,0 +1,53 @@
+"""Functions that validate array layouts."""
+
+from ..spatial_arrays import ArrayAxis, ArrayLayout
+
+
+# layout validators
+def validate_ZYX_ordering(layout: ArrayLayout) -> None:
+    """Validate that the layout has Z, Y, X axes in that order (with any staggers)."""
+    expected_axes = (ArrayAxis.Z, ArrayAxis.Y, ArrayAxis.X)
+    if layout.axes != expected_axes:
+        raise ValueError(f"Expected axes {expected_axes} but got {layout.axes}")
+
+
+def validate_ZY_ordering(layout: ArrayLayout) -> None:
+    """Validate that the layout has Z, Y axes in that order (with any staggers)."""
+    expected_axes = (ArrayAxis.Z, ArrayAxis.Y)
+    if layout.axes != expected_axes:
+        raise ValueError(f"Expected axes {expected_axes} but got {layout.axes}")
+
+
+def validate_YX_ordering(layout: ArrayLayout) -> None:
+    """Validate that the layout has Y, X axes in that order (with any staggers)."""
+    expected_axes = (ArrayAxis.Y, ArrayAxis.X)
+    if layout.axes != expected_axes:
+        raise ValueError(f"Expected axes {expected_axes} but got {layout.axes}")
+
+
+def validate_ZX_ordering(layout: ArrayLayout) -> None:
+    """Validate that the layout has Z, X axes in that order (with any staggers)."""
+    expected_axes = (ArrayAxis.Z, ArrayAxis.X)
+    if layout.axes != expected_axes:
+        raise ValueError(f"Expected axes {expected_axes} but got {layout.axes}")
+
+
+def validate_Z_ordering(layout: ArrayLayout) -> None:
+    """Validate that the layout has a single Z axis (with any staggers)."""
+    expected_axes = (ArrayAxis.Z,)
+    if layout.axes != expected_axes:
+        raise ValueError(f"Expected axes {expected_axes} but got {layout.axes}")
+
+
+def validate_Y_ordering(layout: ArrayLayout) -> None:
+    """Validate that the layout has a single Y axis (with any staggers)."""
+    expected_axes = (ArrayAxis.Y,)
+    if layout.axes != expected_axes:
+        raise ValueError(f"Expected axes {expected_axes} but got {layout.axes}")
+
+
+def validate_X_ordering(layout: ArrayLayout) -> None:
+    """Validate that the layout has a single X axis (with any staggers)."""
+    expected_axes = (ArrayAxis.X,)
+    if layout.axes != expected_axes:
+        raise ValueError(f"Expected axes {expected_axes} but got {layout.axes}")

--- a/src/offline_particles/kernels/relaxation/__init__.py
+++ b/src/offline_particles/kernels/relaxation/__init__.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from .._kernels import BoundKernel, ParticleKernel, ParticlePropertyDeclaration, ScalarDeclaration
-from ..common_inputs import STATUS_DECLARATION
+from ..input_declarations import STATUS_DECLARATION
 from ._relaxation import (
     linear_damping_accumulation,
     linear_relaxation_accumulation,

--- a/src/offline_particles/kernels/roms/horizontal_advection/__init__.py
+++ b/src/offline_particles/kernels/roms/horizontal_advection/__init__.py
@@ -2,21 +2,17 @@
 
 import numpy as np
 
-from ....spatial_arrays import ACTIVE_STAGGERS, INACTIVE_STAGGERS
 from ..._kernels import BoundKernel, FieldDataDeclaration, ParticleKernel, ParticlePropertyDeclaration
-from ...common_inputs import STATUS_DECLARATION, XIDX_DECLARATION, YIDX_DECLARATION, ZIDX_DECLARATION
+from ...input_declarations import STATUS_DECLARATION, XIDX_DECLARATION, YIDX_DECLARATION, ZIDX_DECLARATION
+from ...layout_validators import validate_YX_ordering, validate_ZYX_ordering
 from .linear_interpolation import (
     horizontal_idx_tendency_from_velocity_field,
     horizontal_idx_tendency_from_velocity_property,
 )
 
 didx_declaration = ParticlePropertyDeclaration("didx", np.float64)
-velocity_field_declaration = FieldDataDeclaration(
-    "velocity", np.float64, z_staggers=ACTIVE_STAGGERS, y_staggers=ACTIVE_STAGGERS, x_staggers=ACTIVE_STAGGERS
-)
-grid_spacing_declaration = FieldDataDeclaration(
-    "grid_spacing", np.float64, z_staggers=INACTIVE_STAGGERS, y_staggers=ACTIVE_STAGGERS, x_staggers=ACTIVE_STAGGERS
-)
+velocity_field_declaration = FieldDataDeclaration("velocity", np.float64, [validate_ZYX_ordering])
+grid_spacing_declaration = FieldDataDeclaration("grid_spacing", np.float64, [validate_YX_ordering])
 vel_property_declaration = ParticlePropertyDeclaration("vel", np.float64)
 
 

--- a/src/offline_particles/kernels/roms/vertical_coordinate/__init__.py
+++ b/src/offline_particles/kernels/roms/vertical_coordinate/__init__.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 
-from ....spatial_arrays import ACTIVE_STAGGERS, INACTIVE_STAGGERS
 from ..._kernels import (
     BoundKernel,
     FieldDataDeclaration,
@@ -10,7 +9,8 @@ from ..._kernels import (
     ParticlePropertyDeclaration,
     ScalarDeclaration,
 )
-from ...common_inputs import STATUS_DECLARATION, XIDX_DECLARATION, YIDX_DECLARATION, ZIDX_DECLARATION
+from ...input_declarations import STATUS_DECLARATION, XIDX_DECLARATION, YIDX_DECLARATION, ZIDX_DECLARATION
+from ...layout_validators import validate_YX_ordering, validate_Z_ordering, validate_ZYX_ordering
 from .vertical_coordinate import compute_z_kernel_function, compute_zidx_kernel_function
 
 __all__ = [
@@ -21,15 +21,9 @@ __all__ = [
 z_declaration = ParticlePropertyDeclaration("z", np.float64)
 hc_declaration = ScalarDeclaration("hc", np.float64)
 NZ_declaration = ScalarDeclaration("NZ", np.int32)
-h_declaration = FieldDataDeclaration(
-    "h", np.float64, z_staggers=INACTIVE_STAGGERS, y_staggers=ACTIVE_STAGGERS, x_staggers=ACTIVE_STAGGERS
-)
-zeta_declaration = FieldDataDeclaration(
-    "zeta", np.float64, z_staggers=INACTIVE_STAGGERS, y_staggers=ACTIVE_STAGGERS, x_staggers=ACTIVE_STAGGERS
-)
-C_declaration = FieldDataDeclaration(
-    "C", np.float64, z_staggers=ACTIVE_STAGGERS, y_staggers=INACTIVE_STAGGERS, x_staggers=INACTIVE_STAGGERS
-)
+h_declaration = FieldDataDeclaration("h", np.float64, [validate_ZYX_ordering])
+zeta_declaration = FieldDataDeclaration("zeta", np.float64, [validate_YX_ordering])
+C_declaration = FieldDataDeclaration("C", np.float64, [validate_Z_ordering])
 
 
 def construct_compute_z_kernel(

--- a/src/offline_particles/kernels/roms/vertical_coordinate/__init__.py
+++ b/src/offline_particles/kernels/roms/vertical_coordinate/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
 z_declaration = ParticlePropertyDeclaration("z", np.float64)
 hc_declaration = ScalarDeclaration("hc", np.float64)
 NZ_declaration = ScalarDeclaration("NZ", np.int32)
-h_declaration = FieldDataDeclaration("h", np.float64, [validate_ZYX_ordering])
+h_declaration = FieldDataDeclaration("h", np.float64, [validate_YX_ordering])
 zeta_declaration = FieldDataDeclaration("zeta", np.float64, [validate_YX_ordering])
 C_declaration = FieldDataDeclaration("C", np.float64, [validate_Z_ordering])
 

--- a/src/offline_particles/kernels/timed_activation/__init__.py
+++ b/src/offline_particles/kernels/timed_activation/__init__.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.typing as npt
 
 from .._kernels import BoundKernel, ParticleKernel, ParticlePropertyDeclaration
-from ..common_inputs import DT_DECLARATION, STATUS_DECLARATION, construct_time_declaration
+from ..input_declarations import DT_DECLARATION, STATUS_DECLARATION, construct_time_declaration
 from ._timed_activation import (
     activate_released_particles,
     deactivate_retired_particles,

--- a/src/offline_particles/kernels/timestepping/adams_bashforth.py
+++ b/src/offline_particles/kernels/timestepping/adams_bashforth.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.typing as npt
 
 from .._kernels import BoundKernel, ParticleKernel, ParticlePropertyDeclaration
-from ..common_inputs import DT_DECLARATION, STATUS_DECLARATION
+from ..input_declarations import DT_DECLARATION, STATUS_DECLARATION
 from ._adams_bashforth import (
     ab2_bump_status,
     ab2_initialisation,

--- a/src/offline_particles/kernels/validation/__init__.py
+++ b/src/offline_particles/kernels/validation/__init__.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from .._kernels import BoundKernel, ParticleKernel, ScalarDeclaration
-from ..common_inputs import STATUS_DECLARATION, XIDX_DECLARATION, YIDX_DECLARATION, ZIDX_DECLARATION
+from ..input_declarations import STATUS_DECLARATION, XIDX_DECLARATION, YIDX_DECLARATION, ZIDX_DECLARATION
 from ._validation import domain_bounds, finite_indices
 
 __all__ = [

--- a/src/offline_particles/output/_linear_interpolation.py
+++ b/src/offline_particles/output/_linear_interpolation.py
@@ -6,13 +6,8 @@ from ..kernels.interpolation import (
     construct_linear_interpolation_kernel,
     construct_trilinear_interpolation_kernel,
 )
+from ..spatial_arrays import ArrayAxis
 from ._output import Output
-
-DMASK_DIM_MAPPING_2D = {
-    (True, True, False): ("zidx", "yidx"),
-    (True, False, True): ("zidx", "xidx"),
-    (False, True, True): ("yidx", "xidx"),
-}
 
 
 def linearly_interpolate_fields(
@@ -28,7 +23,6 @@ def linearly_interpolate_fields(
         variables: The list of variable names to interpolate.
         particle_field_prefix: The prefix for the particle array to store the output data.
     """
-    dims = ("zidx", "yidx", "xidx")
     outputs = {}
 
     for var in variables:
@@ -36,21 +30,26 @@ def linearly_interpolate_fields(
             raise KeyError(f"Field '{var}' not found in fieldset.")
 
         field = fieldset[var]
-        dmask = field.dmask
-        ndim = field.nspatial_dims
         dtype = field.output_dtype
         particle_property = f"{particle_property_prefix}_{dtype}"
 
-        if ndim == 1:
-            dim = dims[dmask.index(True)]
-            kernel = construct_linear_interpolation_kernel(dim, particle_property, var)
-        elif ndim == 2:
-            dim = DMASK_DIM_MAPPING_2D[dmask]
-            kernel = construct_bilinear_interpolation_kernel(dim, particle_property, var)
-        elif ndim == 3:
-            kernel = construct_trilinear_interpolation_kernel(particle_property, var)
-        else:
-            raise ValueError(f"Field '{var}' has unsupported number of dimensions: {ndim}")
+        match field.axes:
+            case (ArrayAxis.Z, ArrayAxis.Y, ArrayAxis.X):
+                kernel = construct_trilinear_interpolation_kernel(particle_property, var)
+            case (ArrayAxis.Z, ArrayAxis.Y):
+                kernel = construct_bilinear_interpolation_kernel(("zidx", "yidx"), particle_property, var)
+            case (ArrayAxis.Z, ArrayAxis.X):
+                kernel = construct_bilinear_interpolation_kernel(("zidx", "xidx"), particle_property, var)
+            case (ArrayAxis.Y, ArrayAxis.X):
+                kernel = construct_bilinear_interpolation_kernel(("yidx", "xidx"), particle_property, var)
+            case (ArrayAxis.Z,):
+                kernel = construct_linear_interpolation_kernel("zidx", particle_property, var)
+            case (ArrayAxis.Y,):
+                kernel = construct_linear_interpolation_kernel("yidx", particle_property, var)
+            case (ArrayAxis.X,):
+                kernel = construct_linear_interpolation_kernel("xidx", particle_property, var)
+            case _:
+                raise ValueError(f"Field '{var}' has unsupported axes: {field.axes}")
 
         name = f"{particle_set}:{var}"
         outputs[name] = Output(particle_set, particle_property, kernel)

--- a/src/offline_particles/output/_linear_interpolation.py
+++ b/src/offline_particles/output/_linear_interpolation.py
@@ -21,7 +21,7 @@ def linearly_interpolate_fields(
     Args:
         fieldset: The fieldset containing the fields to interpolate.
         variables: The list of variable names to interpolate.
-        particle_field_prefix: The prefix for the particle array to store the output data.
+        particle_property_prefix: The prefix for the particle array to store the output data.
     """
     outputs = {}
 

--- a/src/offline_particles/spatial_arrays.py
+++ b/src/offline_particles/spatial_arrays.py
@@ -197,7 +197,7 @@ class SpatialArray(abc.ABC):
         return self._layout.staggers
 
     @property
-    def offsets(self) -> tuple[float]:
+    def offsets(self) -> tuple[float, ...]:
         """Offsets for all dimensions."""
         return self._layout.offsets
 
@@ -306,7 +306,7 @@ class ChunkedDaskArray(SpatialArray):
         self._chunk_boundaries = tuple(np.cumulative_sum(chunk, include_initial=True) for chunk in self._chunks)
         # placeholders for array and bounds of current subset
         self._subset: npt.NDArray[np.generic] = np.zeros((0,) * data.ndim, data.dtype)
-        self._subset_bounds: tuple[tuple[int, int], ...] = ((0, 0),) * self._ndim
+        self._subset_bounds: tuple[tuple[int, int], ...] = ((0, 0),) * self.ndim
 
     @property
     def dtype(self) -> np.dtype:

--- a/src/offline_particles/spatial_arrays.py
+++ b/src/offline_particles/spatial_arrays.py
@@ -4,6 +4,7 @@ import abc
 import dataclasses
 import enum
 import logging
+from typing import Iterable
 
 import dask.array as da
 import numpy as np
@@ -122,6 +123,34 @@ class ArrayAxis(enum.StrEnum):
         except KeyError:
             pass
         raise ValueError(f"'{axis}' is not a valid ArrayAxis value or name")
+
+
+class ArrayLayout:
+    """Specification of a spatial array's axes and staggering."""
+
+    __slots__ = ("ndims", "axes", "staggers", "offsets")
+
+    def __init__(self, axes: Iterable[ArrayAxis | str], staggers: Iterable[Stagger | str]) -> None:
+        axes = tuple(ArrayAxis.parse(axis) for axis in axes)
+        staggers = tuple(Stagger(s) for s in staggers)
+
+        # validation
+        if len(axes) != len(staggers):
+            raise ValueError("Number of axes and staggers must match")
+        if len(set(axes)) != len(axes):
+            raise ValueError("Axes must be unique")
+
+        # set attributes
+        object.__setattr__(self, "ndims", len(self.axes))
+        object.__setattr__(self, "axes", axes)
+        object.__setattr__(self, "staggers", staggers)
+        object.__setattr__(self, "offsets", tuple(s.offset for s in staggers))
+
+    def __setattr__(self, name, value):
+        raise AttributeError("ArrayLayout is immutable")
+
+    def __delattr__(self, name):
+        raise AttributeError("ArrayLayout is immutable")
 
 
 @dataclasses.dataclass(frozen=True, slots=True)

--- a/src/offline_particles/spatial_arrays.py
+++ b/src/offline_particles/spatial_arrays.py
@@ -130,6 +130,12 @@ class ArrayLayout:
 
     __slots__ = ("ndim", "axes", "staggers", "offsets")
 
+    # Type annotations for the type checker
+    ndim: int
+    axes: tuple[ArrayAxis, ...]
+    staggers: tuple[Stagger, ...]
+    offsets: tuple[float, ...]
+
     def __init__(self, axes: Iterable[ArrayAxis | str], staggers: Iterable[Stagger | str]) -> None:
         axes = tuple(ArrayAxis.parse(axis) for axis in axes)
         staggers = tuple(Stagger(s) for s in staggers)
@@ -141,7 +147,7 @@ class ArrayLayout:
             raise ValueError("Axes must be unique")
 
         # set attributes
-        object.__setattr__(self, "ndim", len(self.axes))
+        object.__setattr__(self, "ndim", len(axes))
         object.__setattr__(self, "axes", axes)
         object.__setattr__(self, "staggers", staggers)
         object.__setattr__(self, "offsets", tuple(s.offset for s in staggers))

--- a/src/offline_particles/spatial_arrays.py
+++ b/src/offline_particles/spatial_arrays.py
@@ -164,15 +164,6 @@ class BBox:
     xmin: float
     xmax: float
 
-    @property
-    def by_dimension(self) -> tuple[tuple[float, float], tuple[float, float], tuple[float, float]]:
-        """Bounding box organized by dimension."""
-        return (
-            (self.zmin, self.zmax),
-            (self.ymin, self.ymax),
-            (self.xmin, self.xmax),
-        )
-
     def axis_bounds(self, axis: ArrayAxis) -> tuple[float, float]:
         """Get the bounding box limits for a specific axis."""
         match axis:

--- a/src/offline_particles/spatial_arrays.py
+++ b/src/offline_particles/spatial_arrays.py
@@ -22,10 +22,9 @@ class Stagger(enum.StrEnum):
     RIGHT = "right"
     INNER = "inner"
     OUTER = "outer"
-    INVARIANT = "invariant"
 
     @property
-    def offset(self) -> float | None:
+    def offset(self) -> float:
         """Offset between centered indices and staggered indices."""
         match self:
             case Stagger.CENTER:
@@ -34,10 +33,8 @@ class Stagger(enum.StrEnum):
                 return 0.5
             case Stagger.RIGHT | Stagger.INNER:
                 return -0.5
-            case Stagger.INVARIANT:
-                return None
 
-    def expected_size(self, N: int) -> int | None:
+    def expected_size(self, N: int) -> int:
         """Expected size of dimension given size of centered dimension."""
         match self:
             case Stagger.CENTER | Stagger.LEFT | Stagger.RIGHT:
@@ -46,16 +43,6 @@ class Stagger(enum.StrEnum):
                 return N + 1
             case Stagger.INNER:
                 return N - 1
-            case Stagger.INVARIANT:
-                return None
-
-    @property
-    def is_invariant(self) -> bool:
-        return self is Stagger.INVARIANT
-
-    @property
-    def is_active(self) -> bool:
-        return self is not Stagger.INVARIANT
 
     @property
     def on_face(self) -> bool:
@@ -70,9 +57,6 @@ class Stagger(enum.StrEnum):
 ALL_STAGGERS = frozenset(Stagger)
 CENTERED_STAGGERS = frozenset({Stagger.CENTER})
 ON_FACE_STAGGERS = frozenset({s for s in Stagger if s.on_face})
-ACTIVE_STAGGERS = frozenset({s for s in Stagger if s.is_active})
-INVARIANT_STAGGERS = frozenset({Stagger.INVARIANT})
-INACTIVE_STAGGERS = frozenset({s for s in Stagger if not s.is_active})
 
 
 class ArrayAxis(enum.StrEnum):

--- a/src/offline_particles/spatial_arrays.py
+++ b/src/offline_particles/spatial_arrays.py
@@ -128,7 +128,7 @@ class ArrayAxis(enum.StrEnum):
 class ArrayLayout:
     """Specification of a spatial array's axes and staggering."""
 
-    __slots__ = ("ndims", "axes", "staggers", "offsets")
+    __slots__ = ("ndim", "axes", "staggers", "offsets")
 
     def __init__(self, axes: Iterable[ArrayAxis | str], staggers: Iterable[Stagger | str]) -> None:
         axes = tuple(ArrayAxis.parse(axis) for axis in axes)
@@ -141,7 +141,7 @@ class ArrayLayout:
             raise ValueError("Axes must be unique")
 
         # set attributes
-        object.__setattr__(self, "ndims", len(self.axes))
+        object.__setattr__(self, "ndim", len(self.axes))
         object.__setattr__(self, "axes", axes)
         object.__setattr__(self, "staggers", staggers)
         object.__setattr__(self, "offsets", tuple(s.offset for s in staggers))
@@ -173,80 +173,52 @@ class BBox:
             (self.xmin, self.xmax),
         )
 
+    def axis_bounds(self, axis: ArrayAxis) -> tuple[float, float]:
+        """Get the bounding box limits for a specific axis."""
+        match axis:
+            case ArrayAxis.Z:
+                return self.zmin, self.zmax
+            case ArrayAxis.Y:
+                return self.ymin, self.ymax
+            case ArrayAxis.X:
+                return self.xmin, self.xmax
+            case _:
+                raise ValueError(f"Invalid axis: {axis}")
+
 
 class SpatialArray(abc.ABC):
     """Abstract base class for arrays of spatial data."""
 
     def __init__(
         self,
-        z_stagger: Stagger,
-        y_stagger: Stagger,
-        x_stagger: Stagger,
+        layout: ArrayLayout,
     ) -> None:
-        self._z_stagger = z_stagger
-        self._y_stagger = y_stagger
-        self._x_stagger = x_stagger
-        self._z_offset = z_stagger.offset
-        self._y_offset = y_stagger.offset
-        self._x_offset = x_stagger.offset
+        self._layout = layout
 
     @property
-    def z_stagger(self) -> Stagger:
-        """Staggering of the z dimension."""
-        return self._z_stagger
+    def layout(self) -> ArrayLayout:
+        """Layout specification of the spatial array."""
+        return self._layout
 
     @property
-    def y_stagger(self) -> Stagger:
-        """Staggering of the y dimension."""
-        return self._y_stagger
+    def ndim(self) -> int:
+        """Number of dimensions in the spatial array."""
+        return self._layout.ndim
 
     @property
-    def x_stagger(self) -> Stagger:
-        """Staggering of the x dimension."""
-        return self._x_stagger
+    def axes(self) -> tuple[ArrayAxis, ...]:
+        """Axes of the spatial array."""
+        return self._layout.axes
 
     @property
-    def stagger(self) -> tuple[Stagger, Stagger, Stagger]:
-        """Staggering of the (z, y, x) dimensions."""
-        return (self._z_stagger, self._y_stagger, self._x_stagger)
+    def staggers(self) -> tuple[Stagger, ...]:
+        """Staggering of the dimensions."""
+        return self._layout.staggers
 
     @property
-    def z_offset(self) -> float | None:
-        """Offset of the z dimension."""
-        return self._z_offset
-
-    @property
-    def y_offset(self) -> float | None:
-        """Offset of the y dimension."""
-        return self._y_offset
-
-    @property
-    def x_offset(self) -> float | None:
-        """Offset of the x dimension."""
-        return self._x_offset
-
-    @property
-    def offsets(self) -> tuple[float | None, float | None, float | None]:
-        """Offset of the (z, y, x) dimensions."""
-        return (self._z_offset, self._y_offset, self._x_offset)
-
-    @property
-    def dmask(self) -> tuple[bool, bool, bool]:
-        """Mask indicating which dimensions are active."""
-        return (
-            self._z_stagger.is_active,
-            self._y_stagger.is_active,
-            self._x_stagger.is_active,
-        )
-
-    @property
-    def active_offsets(self) -> tuple[float, ...]:
-        """Offsets for active dimensions only."""
-        return tuple(
-            offset
-            for offset, is_active in zip((self._z_offset, self._y_offset, self._x_offset), self.dmask)
-            if is_active
-        )
+    def offsets(self) -> tuple[float]:
+        """Offsets for all dimensions."""
+        return self._layout.offsets
 
     @property
     @abc.abstractmethod
@@ -290,12 +262,15 @@ class NumpyArray(SpatialArray):
     def __init__(
         self,
         data: npt.ArrayLike,
-        z_stagger: Stagger,
-        y_stagger: Stagger,
-        x_stagger: Stagger,
+        layout: ArrayLayout,
     ) -> None:
-        super().__init__(z_stagger, y_stagger, x_stagger)
-        self._data = np.array(data)
+        super().__init__(layout)
+        self._data = np.asarray(data)
+
+        if self._data.ndim != self.layout.ndim:
+            raise ValueError(
+                f"Data array has {self._data.ndim} dimensions but layout specifies {self.layout.ndim} dimensions."
+            )
 
     @property
     def dtype(self) -> np.dtype:
@@ -328,7 +303,7 @@ class NumpyArray(SpatialArray):
             This accounts for both the grid staggering and any subsetting of the data array.
         """
         # Here all the data is in memory so we can just return the full data array and the indices unchanged
-        return self._data, self.active_offsets
+        return self._data, self.offsets
 
 
 class ChunkedDaskArray(SpatialArray):
@@ -337,22 +312,17 @@ class ChunkedDaskArray(SpatialArray):
     def __init__(
         self,
         data: da.Array,
-        z_stagger: Stagger,
-        y_stagger: Stagger,
-        x_stagger: Stagger,
+        layout: ArrayLayout,
     ) -> None:
-        super().__init__(z_stagger, y_stagger, x_stagger)
+        super().__init__(layout)
         if not isinstance(data, da.Array):
             raise TypeError(f"Expected a Dask array, got {type(data).__name__}")
-        if data.ndim != sum(self.dmask):
-            raise ValueError(
-                f"Data array has {data.ndim} dimensions but {sum(self.dmask)} active dimensions were specified."
-            )
+        if data.ndim != self.layout.ndim:
+            raise ValueError(f"Data array has {data.ndim} dimensions but {self.layout.ndim} dimensions were specified.")
         self._data = data
-        self._ndim = self._data.ndim
         self._shape = self._data.shape
         self._chunks = data.chunks
-        self._bounds = tuple(np.cumulative_sum(chunk, include_initial=True) for chunk in self._chunks)
+        self._chunk_boundaries = tuple(np.cumulative_sum(chunk, include_initial=True) for chunk in self._chunks)
         # placeholders for array and bounds of current subset
         self._subset: npt.NDArray[np.generic] = np.zeros((0,) * data.ndim, data.dtype)
         self._subset_bounds: tuple[tuple[int, int], ...] = ((0, 0),) * self._ndim
@@ -387,16 +357,19 @@ class ChunkedDaskArray(SpatialArray):
             Offsets to apply to the active particle indices in order to index into the returned data.
             This accounts for both the grid staggering and any subsetting of the data array.
         """
-        # loop through active dimensions and compute new bounds
-        active_bbox = tuple(
-            dim_bounds for dim_bounds, is_active in zip(bounding_box.by_dimension, self.dmask) if is_active
-        )
-        active_offsets = self.active_offsets
+        offsets = self.offsets
+
+        # get bounding box by axis
+        axis_bounds = (bounding_box.axis_bounds(axis) for axis in self.axes)
+
+        # compute new bounds for each axis based on the bounding box, stagger offsets, and chunk boundaries
         new_bounds = tuple(
-            _compute_new_bounds(db, offset, bounds)
-            for db, offset, bounds in zip(active_bbox, active_offsets, self._bounds)
+            _compute_new_bounds(axis_bound, offset, bounds)
+            for axis_bound, offset, bounds in zip(axis_bounds, offsets, self._chunk_boundaries)
         )
-        new_offsets = tuple(offset - lb for offset, (lb, _) in zip(active_offsets, new_bounds))
+
+        # compute new offsets given thee new bounds
+        new_offsets = tuple(offset - lb for offset, (lb, _) in zip(offsets, new_bounds))
 
         # if new bounds don't match existing update and load new subset
         if self._subset_bounds != new_bounds:

--- a/tests/fields/test_constructor_type_checks.py
+++ b/tests/fields/test_constructor_type_checks.py
@@ -5,117 +5,123 @@ import numpy as np
 import pytest
 
 from offline_particles.fields import StaticField, TimeDependentField
-from offline_particles.spatial_arrays import ChunkedDaskArray, Stagger
+from offline_particles.spatial_arrays import ArrayLayout, ChunkedDaskArray
 
+AXES_ARGS = ("Z", "Y", "X")
 STAGGER_ARGS = ("center", "center", "center")
+LAYOUT = ArrayLayout(AXES_ARGS, STAGGER_ARGS)
+
+AXES_ARGS_2D = ("Y", "X")
+STAGGER_ARGS_2D = ("center", "center")
+LAYOUT_2D = ArrayLayout(AXES_ARGS_2D, STAGGER_ARGS_2D)
 
 
 class TestStaticFieldFromNumpy:
     def test_accepts_numpy_array(self) -> None:
         data = np.ones((4, 5, 6), dtype=np.float64)
-        field = StaticField.from_numpy(data, *STAGGER_ARGS)
+        field = StaticField.from_numpy(data, AXES_ARGS, STAGGER_ARGS)
         assert isinstance(field, StaticField)
 
     def test_rejects_dask_array(self) -> None:
         data = da.ones((4, 5, 6), dtype=np.float64)
         with pytest.raises(TypeError, match="NumPy array"):
-            StaticField.from_numpy(data, *STAGGER_ARGS)  # type: ignore[arg-type]
+            StaticField.from_numpy(data, AXES_ARGS, STAGGER_ARGS)  # type: ignore[arg-type]
 
     def test_rejects_list(self) -> None:
         data = [[[1.0, 2.0], [3.0, 4.0]]]
         with pytest.raises(TypeError, match="NumPy array"):
-            StaticField.from_numpy(data, *STAGGER_ARGS)  # type: ignore[arg-type]
+            StaticField.from_numpy(data, AXES_ARGS, STAGGER_ARGS)  # type: ignore[arg-type]
 
 
 class TestStaticFieldFromDask:
     def test_accepts_dask_array(self) -> None:
         data = da.ones((4, 5, 6), dtype=np.float64, chunks=(4, 5, 6))
-        field = StaticField.from_dask(data, *STAGGER_ARGS)
+        field = StaticField.from_dask(data, AXES_ARGS, STAGGER_ARGS)
         assert isinstance(field, StaticField)
 
     def test_rejects_numpy_array(self) -> None:
         data = np.ones((4, 5, 6), dtype=np.float64)
         with pytest.raises(TypeError, match="Dask array"):
-            StaticField.from_dask(data, *STAGGER_ARGS)  # type: ignore[arg-type]
+            StaticField.from_dask(data, AXES_ARGS, STAGGER_ARGS)  # type: ignore[arg-type]
 
     def test_rejects_list(self) -> None:
         data = [[[1.0, 2.0], [3.0, 4.0]]]
         with pytest.raises(TypeError, match="Dask array"):
-            StaticField.from_dask(data, *STAGGER_ARGS)  # type: ignore[arg-type]
+            StaticField.from_dask(data, AXES_ARGS, STAGGER_ARGS)  # type: ignore[arg-type]
 
 
 class TestTimeDependentFieldFromNumpy:
     def test_accepts_numpy_array(self) -> None:
         data = np.ones((3, 4, 5, 6), dtype=np.float64)
-        field = TimeDependentField.from_numpy(data, *STAGGER_ARGS)
+        field = TimeDependentField.from_numpy(data, AXES_ARGS, STAGGER_ARGS)
         assert isinstance(field, TimeDependentField)
 
     def test_rejects_dask_array(self) -> None:
         data = da.ones((3, 4, 5, 6), dtype=np.float64)
         with pytest.raises(TypeError, match="NumPy array"):
-            TimeDependentField.from_numpy(data, *STAGGER_ARGS)  # type: ignore[arg-type]
+            TimeDependentField.from_numpy(data, AXES_ARGS, STAGGER_ARGS)  # type: ignore[arg-type]
 
     def test_rejects_list(self) -> None:
         data = [[[[1.0, 2.0]], [[3.0, 4.0]]], [[[5.0, 6.0]], [[7.0, 8.0]]]]
         with pytest.raises(TypeError, match="NumPy array"):
-            TimeDependentField.from_numpy(data, *STAGGER_ARGS)  # type: ignore[arg-type]
+            TimeDependentField.from_numpy(data, AXES_ARGS, STAGGER_ARGS)  # type: ignore[arg-type]
 
 
 class TestTimeDependentFieldFromDask:
     def test_accepts_dask_array(self) -> None:
         data = da.ones((3, 4, 5, 6), dtype=np.float64, chunks=(1, 4, 5, 6))
-        field = TimeDependentField.from_dask(data, *STAGGER_ARGS)
+        field = TimeDependentField.from_dask(data, AXES_ARGS, STAGGER_ARGS)
         assert isinstance(field, TimeDependentField)
 
     def test_rejects_numpy_array(self) -> None:
         data = np.ones((3, 4, 5, 6), dtype=np.float64)
         with pytest.raises(TypeError, match="Dask array"):
-            TimeDependentField.from_dask(data, *STAGGER_ARGS)  # type: ignore[arg-type]
+            TimeDependentField.from_dask(data, AXES_ARGS, STAGGER_ARGS)  # type: ignore[arg-type]
 
     def test_rejects_list(self) -> None:
         data = [[[[1.0, 2.0]], [[3.0, 4.0]]], [[[5.0, 6.0]], [[7.0, 8.0]]]]
         with pytest.raises(TypeError, match="Dask array"):
-            TimeDependentField.from_dask(data, *STAGGER_ARGS)  # type: ignore[arg-type]
+            TimeDependentField.from_dask(data, AXES_ARGS, STAGGER_ARGS)  # type: ignore[arg-type]
 
 
 class TestChunkedDaskArrayTypeCheck:
     def test_accepts_dask_array(self) -> None:
         data = da.ones((4, 5, 6), dtype=np.float64, chunks=(4, 5, 6))
-        arr = ChunkedDaskArray(data, Stagger.CENTER, Stagger.CENTER, Stagger.CENTER)
+        arr = ChunkedDaskArray(data, LAYOUT)
         assert arr.shape == (4, 5, 6)
 
     def test_rejects_numpy_array(self) -> None:
         data = np.ones((4, 5, 6), dtype=np.float64)
         with pytest.raises(TypeError, match="Dask array"):
-            ChunkedDaskArray(data, Stagger.CENTER, Stagger.CENTER, Stagger.CENTER)  # type: ignore[arg-type]
+            ChunkedDaskArray(data, LAYOUT)  # type: ignore[arg-type]
 
     def test_rejects_list(self) -> None:
         data = [[[1.0, 2.0], [3.0, 4.0]]]
         with pytest.raises(TypeError, match="Dask array"):
-            ChunkedDaskArray(data, Stagger.CENTER, Stagger.CENTER, Stagger.CENTER)  # type: ignore[arg-type]
+            ChunkedDaskArray(data, LAYOUT)  # type: ignore[arg-type]
 
 
 class TestStaticFieldFromArraylike:
     def test_accepts_list(self) -> None:
         data = [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]
-        field = StaticField.from_arraylike(data, *STAGGER_ARGS)
+        field = StaticField.from_arraylike(data, AXES_ARGS, STAGGER_ARGS)
         assert isinstance(field, StaticField)
 
     def test_accepts_numpy_array(self) -> None:
         data = np.ones((4, 5, 6), dtype=np.float64)
-        field = StaticField.from_arraylike(data, *STAGGER_ARGS)
+        field = StaticField.from_arraylike(data, AXES_ARGS, STAGGER_ARGS)
         assert isinstance(field, StaticField)
 
     def test_converts_to_numpy(self) -> None:
         data = [[1.0, 2.0], [3.0, 4.0]]
-        field = StaticField.from_arraylike(data, "invariant", "center", "center")
+        field = StaticField.from_arraylike(data, AXES_ARGS_2D, STAGGER_ARGS_2D)
         assert isinstance(field, StaticField)
         assert field.dtype == np.float64
 
     def test_warns_on_dask_array(self) -> None:
         data = da.ones((4, 5, 6), dtype=np.float64, chunks=(4, 5, 6))
         with pytest.warns(UserWarning, match="dask.array.Array"):
-            field = StaticField.from_arraylike(data, *STAGGER_ARGS)
+            field = StaticField.from_arraylike(data, AXES_ARGS, STAGGER_ARGS)
         assert isinstance(field, StaticField)
 
 
@@ -125,22 +131,22 @@ class TestTimeDependentFieldFromArraylike:
             [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]],
             [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]],
         ]
-        field = TimeDependentField.from_arraylike(data, *STAGGER_ARGS)
+        field = TimeDependentField.from_arraylike(data, AXES_ARGS, STAGGER_ARGS)
         assert isinstance(field, TimeDependentField)
 
     def test_accepts_numpy_array(self) -> None:
         data = np.ones((3, 4, 5, 6), dtype=np.float64)
-        field = TimeDependentField.from_arraylike(data, *STAGGER_ARGS)
+        field = TimeDependentField.from_arraylike(data, AXES_ARGS, STAGGER_ARGS)
         assert isinstance(field, TimeDependentField)
 
     def test_converts_to_numpy(self) -> None:
         data = [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]
-        field = TimeDependentField.from_arraylike(data, "invariant", "center", "center")
+        field = TimeDependentField.from_arraylike(data, AXES_ARGS_2D, STAGGER_ARGS_2D)
         assert isinstance(field, TimeDependentField)
         assert field.dtype == np.float64
 
     def test_warns_on_dask_array(self) -> None:
         data = da.ones((3, 4, 5, 6), dtype=np.float64, chunks=(1, 4, 5, 6))
         with pytest.warns(UserWarning, match="dask.array.Array"):
-            field = TimeDependentField.from_arraylike(data, *STAGGER_ARGS)
+            field = TimeDependentField.from_arraylike(data, AXES_ARGS, STAGGER_ARGS)
         assert isinstance(field, TimeDependentField)

--- a/tests/fields/test_from_xarray.py
+++ b/tests/fields/test_from_xarray.py
@@ -6,17 +6,16 @@ import pytest
 import xarray as xr
 
 from offline_particles.fields import StaticField, TimeDependentField
+from offline_particles.spatial_arrays import ArrayAxis, Stagger
 
 
 class TestStaticFieldFromXarray:
     def test_3d_numpy_backed(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5), dtype=np.float64), dims=["z", "y", "x"])
-        field = StaticField.from_xarray(data, z=("Z", "center"), y=("Y", "center"), x=("X", "center"))
+        field = StaticField.from_xarray(data, {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")})
         assert isinstance(field, StaticField)
         assert field.spatial_shape == (3, 4, 5)
-        assert field.z_stagger.value == "center"
-        assert field.y_stagger.value == "center"
-        assert field.x_stagger.value == "center"
+        assert field.staggers == (Stagger.CENTER, Stagger.CENTER, Stagger.CENTER)
 
     def test_3d_positional_mapping(self) -> None:
         """Should work when dims is passed as a positional mapping instead of kwargs."""
@@ -37,48 +36,41 @@ class TestStaticFieldFromXarray:
     def test_error_both_dims_and_kwargs(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5), dtype=np.float64), dims=["z", "y", "x"])
         with pytest.raises(TypeError, match="cannot specify both 'dims' and keyword arguments"):
-            StaticField.from_xarray(data, {"z": ("Z", "center")}, y=("Y", "center"), x=("X", "center"))
+            StaticField.from_xarray(data, {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")})
 
     def test_2d_numpy_backed_no_z(self) -> None:
         """Creating from a 2D (y, x) DataArray should succeed (Z axis absent)."""
         data = xr.DataArray(np.ones((4, 5), dtype=np.float64), dims=["y", "x"])
-        field = StaticField.from_xarray(data, y=("Y", "center"), x=("X", "center"))
+        field = StaticField.from_xarray(data, {"y": ("Y", "center"), "x": ("X", "center")})
         assert isinstance(field, StaticField)
         assert field.spatial_shape == (4, 5)
-        assert field.z_stagger.is_invariant
+        assert ArrayAxis.Z not in field.axes
 
     def test_1d_numpy_backed_x_only(self) -> None:
         """Creating from a 1D (x) DataArray should succeed (Z and Y axes absent)."""
         data = xr.DataArray(np.ones((5,), dtype=np.float64), dims=["x"])
-        field = StaticField.from_xarray(data, x=("X", "center"))
+        field = StaticField.from_xarray(data, {"x": ("X", "center")})
         assert isinstance(field, StaticField)
         assert field.spatial_shape == (5,)
-        assert field.z_stagger.is_invariant
-        assert field.y_stagger.is_invariant
-
-    def test_invariant_z_dimension_squeezed(self) -> None:
-        """A singleton z dimension marked as invariant should be squeezed out."""
-        data = xr.DataArray(np.ones((1, 4, 5), dtype=np.float64), dims=["z", "y", "x"])
-        field = StaticField.from_xarray(data, z=("Z", "invariant"), y=("Y", "center"), x=("X", "center"))
-        assert isinstance(field, StaticField)
-        assert field.spatial_shape == (4, 5)
-        assert field.z_stagger.is_invariant
+        assert ArrayAxis.Z not in field.axes
+        assert ArrayAxis.Y not in field.axes
+        assert ArrayAxis.X in field.axes
 
     def test_3d_dask_backed(self) -> None:
         data = xr.DataArray(da.ones((3, 4, 5), chunks=(3, 4, 5), dtype=np.float64), dims=["z", "y", "x"])
-        field = StaticField.from_xarray(data, z=("Z", "center"), y=("Y", "center"), x=("X", "center"))
+        field = StaticField.from_xarray(data, {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")})
         assert isinstance(field, StaticField)
         assert field.spatial_shape == (3, 4, 5)
 
     def test_attrs_preserved(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5)), dims=["z", "y", "x"], attrs={"units": "m/s"})
-        field = StaticField.from_xarray(data, z=("Z", "center"), y=("Y", "center"), x=("X", "center"))
+        field = StaticField.from_xarray(data, {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")})
         assert field.attrs == {"units": "m/s"}
 
     def test_dim_order_independent(self) -> None:
         """DataArray with (x, y, z) order should be transposed correctly."""
         data = xr.DataArray(np.arange(60, dtype=np.float64).reshape(5, 4, 3), dims=["x", "y", "z"])
-        field = StaticField.from_xarray(data, z=("Z", "center"), y=("Y", "center"), x=("X", "center"))
+        field = StaticField.from_xarray(data, {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")})
         assert isinstance(field, StaticField)
         # after transpose to (z, y, x) shape should be (3, 4, 5)
         assert field.spatial_shape == (3, 4, 5)
@@ -87,34 +79,36 @@ class TestStaticFieldFromXarray:
         # "DEPTH" → ArrayAxis.Z, "LATITUDE" → ArrayAxis.Y, "LON" → ArrayAxis.X
         data = xr.DataArray(np.ones((3, 4, 5), dtype=np.float64), dims=["depth", "lat", "lon"])
         field = StaticField.from_xarray(
-            data, depth=("DEPTH", "center"), lat=("LATITUDE", "center"), lon=("LON", "center")
+            data, {"depth": ("DEPTH", "center"), "lat": ("LATITUDE", "center"), "lon": ("LON", "center")}
         )
         assert isinstance(field, StaticField)
         assert field.spatial_shape == (3, 4, 5)
-        assert field.z_stagger.value == "center"  # DEPTH → Z
-        assert field.y_stagger.value == "center"  # LATITUDE → Y
-        assert field.x_stagger.value == "center"  # LON → X
+        assert ArrayAxis.Z in field.axes
+        assert ArrayAxis.Y in field.axes
+        assert ArrayAxis.X in field.axes
 
     def test_validation_error_missing_dim(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5)), dims=["z", "y", "x"])
         with pytest.raises(ValueError, match="Mismatch"):
-            StaticField.from_xarray(data, z=("Z", "center"), y=("Y", "center"))  # missing x
+            StaticField.from_xarray(data, {"z": ("Z", "center"), "y": ("Y", "center")})  # missing x
 
     def test_validation_error_extra_dim(self) -> None:
         data = xr.DataArray(np.ones((4, 5)), dims=["y", "x"])
         with pytest.raises(ValueError, match="Mismatch"):
-            StaticField.from_xarray(data, z=("Z", "center"), y=("Y", "center"), x=("X", "center"))  # extra z
+            StaticField.from_xarray(data, {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")})  # extra z
 
     def test_validation_error_duplicate_axis(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5)), dims=["z", "y", "x"])
         with pytest.raises(ValueError, match="Multiple dimensions mapped"):
-            StaticField.from_xarray(data, z=("Z", "center"), y=("Z", "center"), x=("X", "center"))
+            StaticField.from_xarray(data, {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")})
 
 
 class TestTimeDependentFieldFromXarray:
     def test_4d_numpy_backed(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5, 6), dtype=np.float64), dims=["t", "z", "y", "x"])
-        field = TimeDependentField.from_xarray(data, "t", z=("Z", "center"), y=("Y", "center"), x=("X", "center"))
+        field = TimeDependentField.from_xarray(
+            data, "t", {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")}
+        )
         assert isinstance(field, TimeDependentField)
         assert field.spatial_shape == (4, 5, 6)
 
@@ -134,51 +128,43 @@ class TestTimeDependentFieldFromXarray:
         assert isinstance(field, TimeDependentField)
         assert field.spatial_shape == (4, 5)
 
-    def test_error_both_dims_and_kwargs(self) -> None:
-        data = xr.DataArray(np.ones((3, 4, 5, 6), dtype=np.float64), dims=["t", "z", "y", "x"])
-        with pytest.raises(TypeError, match="cannot specify both 'dims' and keyword arguments"):
-            TimeDependentField.from_xarray(data, "t", {"z": ("Z", "center")}, y=("Y", "center"), x=("X", "center"))
-
     def test_3d_no_z(self) -> None:
         """Creating from (t, y, x) DataArray should succeed (Z axis absent)."""
         data = xr.DataArray(np.ones((3, 4, 5), dtype=np.float64), dims=["t", "y", "x"])
-        field = TimeDependentField.from_xarray(data, "t", y=("Y", "center"), x=("X", "center"))
+        field = TimeDependentField.from_xarray(data, "t", {"y": ("Y", "center"), "x": ("X", "center")})
         assert isinstance(field, TimeDependentField)
         assert field.spatial_shape == (4, 5)
-        assert field.z_stagger.is_invariant
+        assert ArrayAxis.Z not in field.axes
 
     def test_2d_time_plus_x(self) -> None:
         """Creating from (t, x) DataArray should succeed."""
         data = xr.DataArray(np.ones((3, 5), dtype=np.float64), dims=["t", "x"])
-        field = TimeDependentField.from_xarray(data, "t", x=("X", "center"))
+        field = TimeDependentField.from_xarray(data, "t", {"x": ("X", "center")})
         assert isinstance(field, TimeDependentField)
         assert field.spatial_shape == (5,)
-        assert field.z_stagger.is_invariant
-        assert field.y_stagger.is_invariant
-
-    def test_invariant_z_dimension_squeezed(self) -> None:
-        """A singleton z dimension marked as invariant should be squeezed out."""
-        data = xr.DataArray(np.ones((3, 1, 4, 5), dtype=np.float64), dims=["t", "z", "y", "x"])
-        field = TimeDependentField.from_xarray(data, "t", z=("Z", "invariant"), y=("Y", "center"), x=("X", "center"))
-        assert isinstance(field, TimeDependentField)
-        assert field.spatial_shape == (4, 5)
-        assert field.z_stagger.is_invariant
+        assert ArrayAxis.Z not in field.axes
+        assert ArrayAxis.Y not in field.axes
+        assert ArrayAxis.X in field.axes
 
     def test_4d_dask_backed(self) -> None:
         data = xr.DataArray(da.ones((3, 4, 5, 6), chunks=(1, 4, 5, 6), dtype=np.float64), dims=["t", "z", "y", "x"])
-        field = TimeDependentField.from_xarray(data, "t", z=("Z", "center"), y=("Y", "center"), x=("X", "center"))
+        field = TimeDependentField.from_xarray(
+            data, "t", {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")}
+        )
         assert isinstance(field, TimeDependentField)
         assert field.spatial_shape == (4, 5, 6)
 
     def test_attrs_preserved(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5)), dims=["t", "y", "x"], attrs={"units": "m/s"})
-        field = TimeDependentField.from_xarray(data, "t", y=("Y", "center"), x=("X", "center"))
+        field = TimeDependentField.from_xarray(data, "t", {"y": ("Y", "center"), "x": ("X", "center")})
         assert field.attrs == {"units": "m/s"}
 
     def test_dim_order_independent(self) -> None:
         """DataArray with (z, t, x, y) order should be transposed correctly."""
         data = xr.DataArray(np.ones((4, 3, 6, 5), dtype=np.float64), dims=["z", "t", "x", "y"])
-        field = TimeDependentField.from_xarray(data, "t", z=("Z", "center"), y=("Y", "center"), x=("X", "center"))
+        field = TimeDependentField.from_xarray(
+            data, "t", {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")}
+        )
         assert isinstance(field, TimeDependentField)
         # after transpose to (t, z, y, x) shape should be (3, 4, 5, 6)
         assert field.data.shape == (3, 4, 5, 6)
@@ -186,19 +172,23 @@ class TestTimeDependentFieldFromXarray:
     def test_validation_error_missing_time_dim(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5)), dims=["t", "y", "x"])
         with pytest.raises(ValueError, match="Time dimension 'time' not found"):
-            TimeDependentField.from_xarray(data, "time", y=("Y", "center"), x=("X", "center"))
+            TimeDependentField.from_xarray(data, "time", {"y": ("Y", "center"), "x": ("X", "center")})
 
     def test_validation_error_missing_spatial_dim(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5)), dims=["t", "y", "x"])
         with pytest.raises(ValueError, match="Mismatch"):
-            TimeDependentField.from_xarray(data, "t", y=("Y", "center"))  # missing x
+            TimeDependentField.from_xarray(data, "t", {"y": ("Y", "center")})  # missing x
 
     def test_validation_error_extra_spatial_dim(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5)), dims=["t", "y", "x"])
         with pytest.raises(ValueError, match="Mismatch"):
-            TimeDependentField.from_xarray(data, "t", z=("Z", "center"), y=("Y", "center"), x=("X", "center"))
+            TimeDependentField.from_xarray(
+                data, "t", {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")}
+            )
 
     def test_validation_error_duplicate_axis(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5, 6)), dims=["t", "z", "y", "x"])
         with pytest.raises(ValueError, match="Multiple dimensions mapped"):
-            TimeDependentField.from_xarray(data, "t", z=("Z", "center"), y=("Z", "center"), x=("X", "center"))
+            TimeDependentField.from_xarray(
+                data, "t", {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")}
+            )

--- a/tests/fields/test_from_xarray.py
+++ b/tests/fields/test_from_xarray.py
@@ -17,26 +17,21 @@ class TestStaticFieldFromXarray:
         assert field.spatial_shape == (3, 4, 5)
         assert field.staggers == (Stagger.CENTER, Stagger.CENTER, Stagger.CENTER)
 
-    def test_3d_positional_mapping(self) -> None:
-        """Should work when dims is passed as a positional mapping instead of kwargs."""
+    def test_3d_dims_as_variable(self) -> None:
+        """dims mapping can be passed as a variable."""
         data = xr.DataArray(np.ones((3, 4, 5), dtype=np.float64), dims=["z", "y", "x"])
         dims = {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")}
         field = StaticField.from_xarray(data, dims)
         assert isinstance(field, StaticField)
         assert field.spatial_shape == (3, 4, 5)
 
-    def test_positional_mapping_supports_non_identifier_dim_names(self) -> None:
-        """Dimension names that are not valid Python identifiers require the mapping style."""
+    def test_non_identifier_dim_names(self) -> None:
+        """Dimension names that are not valid Python identifiers are supported."""
         data = xr.DataArray(np.ones((3, 4), dtype=np.float64), dims=["y-coord", "x-coord"])
         dims = {"y-coord": ("Y", "center"), "x-coord": ("X", "center")}
         field = StaticField.from_xarray(data, dims)
         assert isinstance(field, StaticField)
         assert field.spatial_shape == (3, 4)
-
-    def test_error_both_dims_and_kwargs(self) -> None:
-        data = xr.DataArray(np.ones((3, 4, 5), dtype=np.float64), dims=["z", "y", "x"])
-        with pytest.raises(TypeError, match="cannot specify both 'dims' and keyword arguments"):
-            StaticField.from_xarray(data, {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")})
 
     def test_2d_numpy_backed_no_z(self) -> None:
         """Creating from a 2D (y, x) DataArray should succeed (Z axis absent)."""
@@ -67,13 +62,14 @@ class TestStaticFieldFromXarray:
         field = StaticField.from_xarray(data, {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")})
         assert field.attrs == {"units": "m/s"}
 
-    def test_dim_order_independent(self) -> None:
-        """DataArray with (x, y, z) order should be transposed correctly."""
+    def test_dim_order_preserved(self) -> None:
+        """Field preserves the dimension ordering of the input DataArray."""
         data = xr.DataArray(np.arange(60, dtype=np.float64).reshape(5, 4, 3), dims=["x", "y", "z"])
         field = StaticField.from_xarray(data, {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")})
         assert isinstance(field, StaticField)
-        # after transpose to (z, y, x) shape should be (3, 4, 5)
-        assert field.spatial_shape == (3, 4, 5)
+        # field preserves the dim ordering of the xarray DataArray (x, y, z) → shape (5, 4, 3)
+        assert field.axes == (ArrayAxis.X, ArrayAxis.Y, ArrayAxis.Z)
+        assert field.spatial_shape == (5, 4, 3)
 
     def test_aliases_resolve_correctly(self) -> None:
         # "DEPTH" → ArrayAxis.Z, "LATITUDE" → ArrayAxis.Y, "LON" → ArrayAxis.X
@@ -89,18 +85,20 @@ class TestStaticFieldFromXarray:
 
     def test_validation_error_missing_dim(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5)), dims=["z", "y", "x"])
-        with pytest.raises(ValueError, match="Mismatch"):
+        with pytest.raises(ValueError, match="Dimension 'x' in data is missing from dims mapping"):
             StaticField.from_xarray(data, {"z": ("Z", "center"), "y": ("Y", "center")})  # missing x
 
     def test_validation_error_extra_dim(self) -> None:
         data = xr.DataArray(np.ones((4, 5)), dims=["y", "x"])
-        with pytest.raises(ValueError, match="Mismatch"):
+        with pytest.raises(ValueError, match="Dimensions in dims mapping not found in data"):
             StaticField.from_xarray(data, {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")})  # extra z
 
     def test_validation_error_duplicate_axis(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5)), dims=["z", "y", "x"])
-        with pytest.raises(ValueError, match="Multiple dimensions mapped"):
-            StaticField.from_xarray(data, {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")})
+        with pytest.raises(ValueError, match="Axes must be unique"):
+            StaticField.from_xarray(
+                data, {"z": ("Z", "center"), "y": ("Z", "center"), "x": ("X", "center")}
+            )  # both z and y map to Z axis
 
 
 class TestTimeDependentFieldFromXarray:
@@ -112,16 +110,16 @@ class TestTimeDependentFieldFromXarray:
         assert isinstance(field, TimeDependentField)
         assert field.spatial_shape == (4, 5, 6)
 
-    def test_4d_positional_mapping(self) -> None:
-        """Should work when dims is passed as a positional mapping instead of kwargs."""
+    def test_4d_dims_as_variable(self) -> None:
+        """dims mapping can be passed as a variable."""
         data = xr.DataArray(np.ones((3, 4, 5, 6), dtype=np.float64), dims=["t", "z", "y", "x"])
         dims = {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")}
         field = TimeDependentField.from_xarray(data, "t", dims)
         assert isinstance(field, TimeDependentField)
         assert field.spatial_shape == (4, 5, 6)
 
-    def test_positional_mapping_supports_non_identifier_dim_names(self) -> None:
-        """Dimension names that are not valid Python identifiers require the mapping style."""
+    def test_non_identifier_dim_names(self) -> None:
+        """Dimension names that are not valid Python identifiers are supported."""
         data = xr.DataArray(np.ones((3, 4, 5), dtype=np.float64), dims=["t", "y-coord", "x-coord"])
         dims = {"y-coord": ("Y", "center"), "x-coord": ("X", "center")}
         field = TimeDependentField.from_xarray(data, "t", dims)
@@ -159,15 +157,16 @@ class TestTimeDependentFieldFromXarray:
         field = TimeDependentField.from_xarray(data, "t", {"y": ("Y", "center"), "x": ("X", "center")})
         assert field.attrs == {"units": "m/s"}
 
-    def test_dim_order_independent(self) -> None:
-        """DataArray with (z, t, x, y) order should be transposed correctly."""
+    def test_time_dim_moved_to_front(self) -> None:
+        """DataArray with time not at first position: time is moved to front, spatial ordering preserved."""
         data = xr.DataArray(np.ones((4, 3, 6, 5), dtype=np.float64), dims=["z", "t", "x", "y"])
         field = TimeDependentField.from_xarray(
             data, "t", {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")}
         )
         assert isinstance(field, TimeDependentField)
-        # after transpose to (t, z, y, x) shape should be (3, 4, 5, 6)
-        assert field.data.shape == (3, 4, 5, 6)
+        # time moved to front, spatial dims keep original order (z, x, y) → shape (3, 4, 6, 5)
+        assert field.data.shape == (3, 4, 6, 5)
+        assert field.axes == (ArrayAxis.Z, ArrayAxis.X, ArrayAxis.Y)
 
     def test_validation_error_missing_time_dim(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5)), dims=["t", "y", "x"])
@@ -176,19 +175,19 @@ class TestTimeDependentFieldFromXarray:
 
     def test_validation_error_missing_spatial_dim(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5)), dims=["t", "y", "x"])
-        with pytest.raises(ValueError, match="Mismatch"):
+        with pytest.raises(ValueError, match="Dimension 'x' in data is missing from dims mapping"):
             TimeDependentField.from_xarray(data, "t", {"y": ("Y", "center")})  # missing x
 
     def test_validation_error_extra_spatial_dim(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5)), dims=["t", "y", "x"])
-        with pytest.raises(ValueError, match="Mismatch"):
+        with pytest.raises(ValueError, match="Dimensions in dims mapping not found in data"):
             TimeDependentField.from_xarray(
                 data, "t", {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")}
             )
 
     def test_validation_error_duplicate_axis(self) -> None:
         data = xr.DataArray(np.ones((3, 4, 5, 6)), dims=["t", "z", "y", "x"])
-        with pytest.raises(ValueError, match="Multiple dimensions mapped"):
+        with pytest.raises(ValueError, match="Axes must be unique"):
             TimeDependentField.from_xarray(
-                data, "t", {"z": ("Z", "center"), "y": ("Y", "center"), "x": ("X", "center")}
-            )
+                data, "t", {"z": ("Z", "center"), "y": ("Z", "center"), "x": ("X", "center")}
+            )  # both z and y map to Z axis

--- a/tests/fieldset/test_fieldset.py
+++ b/tests/fieldset/test_fieldset.py
@@ -3,14 +3,14 @@
 import numpy as np
 import pytest
 
-from offline_particles.fields import StaticField
+from offline_particles.fields import SimulationSize, StaticField
 from offline_particles.fieldset import Fieldset
 
 
 def _make_static_field(z: int, y: int, x: int) -> StaticField:
     """Create a minimal StaticField for testing."""
     data = np.zeros((z, y, x), dtype=np.float64)
-    return StaticField.from_numpy(data, "center", "center", "center")
+    return StaticField.from_numpy(data, axes=("Z", "Y", "X"), staggers=("center", "center", "center"))
 
 
 # ---------------------------------------------------------------------------
@@ -26,9 +26,9 @@ class TestFieldsetConstruction:
         assert fs.y_size == 5
         assert fs.x_size == 6
 
-    def test_simulation_shape(self) -> None:
+    def test_simulation_size(self) -> None:
         fs = Fieldset(10, 4, 5, 6)
-        assert fs.simulation_shape == (10, 4, 5, 6)
+        assert fs.simulation_size == SimulationSize(10, 4, 5, 6)
 
     def test_default_index_bounds(self) -> None:
         fs = Fieldset(10, 4, 5, 6)
@@ -58,7 +58,7 @@ class TestFieldsetConstruction:
 
     def test_fields_kwarg(self) -> None:
         field = _make_static_field(4, 5, 6)
-        fs = Fieldset(10, 4, 5, 6, u=field)
+        fs = Fieldset(10, 4, 5, 6, fields={"u": field})
         assert "u" in fs.fields
 
 

--- a/tests/kernels/test_layout_validators.py
+++ b/tests/kernels/test_layout_validators.py
@@ -1,0 +1,217 @@
+"""Tests for layout validator functions."""
+
+import pytest
+
+from offline_particles.kernels.layout_validators import (
+    validate_X_ordering,
+    validate_Y_ordering,
+    validate_YX_ordering,
+    validate_Z_ordering,
+    validate_ZX_ordering,
+    validate_ZY_ordering,
+    validate_ZYX_ordering,
+)
+from offline_particles.spatial_arrays import ArrayLayout
+
+
+def _layout(*axes: str, stagger: str = "center") -> ArrayLayout:
+    """Helper: build a layout from axis names all with the same stagger."""
+    return ArrayLayout(axes, (stagger,) * len(axes))
+
+
+class TestValidateZYXOrdering:
+    def test_passes_for_zyx(self) -> None:
+        validate_ZYX_ordering(_layout("Z", "Y", "X"))
+
+    def test_fails_for_xyz(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_ZYX_ordering(_layout("X", "Y", "Z"))
+
+    def test_fails_for_yx(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_ZYX_ordering(_layout("Y", "X"))
+
+    def test_fails_for_z_only(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_ZYX_ordering(_layout("Z"))
+
+    def test_passes_regardless_of_staggers(self) -> None:
+        for stagger in ("center", "left", "right", "inner", "outer"):
+            validate_ZYX_ordering(_layout("Z", "Y", "X", stagger=stagger))
+
+
+class TestValidateZYOrdering:
+    def test_passes_for_zy(self) -> None:
+        validate_ZY_ordering(_layout("Z", "Y"))
+
+    def test_fails_for_yz(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_ZY_ordering(_layout("Y", "Z"))
+
+    def test_fails_for_zyx(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_ZY_ordering(_layout("Z", "Y", "X"))
+
+    def test_fails_for_z_only(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_ZY_ordering(_layout("Z"))
+
+    def test_passes_regardless_of_staggers(self) -> None:
+        for stagger in ("center", "left", "right", "inner", "outer"):
+            validate_ZY_ordering(_layout("Z", "Y", stagger=stagger))
+
+
+class TestValidateYXOrdering:
+    def test_passes_for_yx(self) -> None:
+        validate_YX_ordering(_layout("Y", "X"))
+
+    def test_fails_for_xy(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_YX_ordering(_layout("X", "Y"))
+
+    def test_fails_for_zyx(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_YX_ordering(_layout("Z", "Y", "X"))
+
+    def test_fails_for_y_only(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_YX_ordering(_layout("Y"))
+
+    def test_passes_regardless_of_staggers(self) -> None:
+        for stagger in ("center", "left", "right", "inner", "outer"):
+            validate_YX_ordering(_layout("Y", "X", stagger=stagger))
+
+
+class TestValidateZXOrdering:
+    def test_passes_for_zx(self) -> None:
+        validate_ZX_ordering(_layout("Z", "X"))
+
+    def test_fails_for_xz(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_ZX_ordering(_layout("X", "Z"))
+
+    def test_fails_for_zyx(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_ZX_ordering(_layout("Z", "Y", "X"))
+
+    def test_fails_for_z_only(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_ZX_ordering(_layout("Z"))
+
+    def test_passes_regardless_of_staggers(self) -> None:
+        for stagger in ("center", "left", "right", "inner", "outer"):
+            validate_ZX_ordering(_layout("Z", "X", stagger=stagger))
+
+
+class TestValidateZOrdering:
+    def test_passes_for_z(self) -> None:
+        validate_Z_ordering(_layout("Z"))
+
+    def test_fails_for_y(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_Z_ordering(_layout("Y"))
+
+    def test_fails_for_zy(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_Z_ordering(_layout("Z", "Y"))
+
+    def test_passes_regardless_of_stagger(self) -> None:
+        for stagger in ("center", "left", "right", "inner", "outer"):
+            validate_Z_ordering(_layout("Z", stagger=stagger))
+
+
+class TestValidateYOrdering:
+    def test_passes_for_y(self) -> None:
+        validate_Y_ordering(_layout("Y"))
+
+    def test_fails_for_z(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_Y_ordering(_layout("Z"))
+
+    def test_fails_for_yx(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_Y_ordering(_layout("Y", "X"))
+
+    def test_passes_regardless_of_stagger(self) -> None:
+        for stagger in ("center", "left", "right", "inner", "outer"):
+            validate_Y_ordering(_layout("Y", stagger=stagger))
+
+
+class TestValidateXOrdering:
+    def test_passes_for_x(self) -> None:
+        validate_X_ordering(_layout("X"))
+
+    def test_fails_for_y(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_X_ordering(_layout("Y"))
+
+    def test_fails_for_yx(self) -> None:
+        with pytest.raises(ValueError, match="Expected axes"):
+            validate_X_ordering(_layout("Y", "X"))
+
+    def test_passes_regardless_of_stagger(self) -> None:
+        for stagger in ("center", "left", "right", "inner", "outer"):
+            validate_X_ordering(_layout("X", stagger=stagger))
+
+
+class TestLayoutValidatorsWithFieldDataDeclaration:
+    """Integration tests: FieldDataDeclaration.validate_field uses layout_validators."""
+
+    def test_validate_field_passes_with_correct_layout(self) -> None:
+        import numpy as np
+
+        from offline_particles.fields import StaticField
+        from offline_particles.kernels import FieldDataDeclaration
+
+        data = np.ones((4, 5, 6), dtype=np.float64)
+        field = StaticField.from_numpy(data, ("Z", "Y", "X"), ("center", "center", "center"))
+        decl = FieldDataDeclaration("u", np.float64, [validate_ZYX_ordering])
+        decl.validate_field(field)  # should not raise
+
+    def test_validate_field_raises_on_wrong_layout(self) -> None:
+        import numpy as np
+
+        from offline_particles.fields import StaticField
+        from offline_particles.kernels import FieldDataDeclaration
+
+        data = np.ones((5, 6), dtype=np.float64)
+        field = StaticField.from_numpy(data, ("Y", "X"), ("center", "center"))
+        decl = FieldDataDeclaration("u", np.float64, [validate_ZYX_ordering])
+        with pytest.raises(ValueError, match="Expected axes"):
+            decl.validate_field(field)
+
+    def test_validate_field_passes_with_no_validators(self) -> None:
+        import numpy as np
+
+        from offline_particles.fields import StaticField
+        from offline_particles.kernels import FieldDataDeclaration
+
+        data = np.ones((5, 6), dtype=np.float64)
+        field = StaticField.from_numpy(data, ("Y", "X"), ("center", "center"))
+        decl = FieldDataDeclaration("u", np.float64)
+        decl.validate_field(field)  # no validators → always passes
+
+    def test_validate_field_raises_on_dtype_mismatch(self) -> None:
+        import numpy as np
+
+        from offline_particles.fields import StaticField
+        from offline_particles.kernels import FieldDataDeclaration
+
+        data = np.ones((4, 5, 6), dtype=np.float32)
+        field = StaticField.from_numpy(data, ("Z", "Y", "X"), ("center", "center", "center"))
+        decl = FieldDataDeclaration("u", np.float64, [validate_ZYX_ordering])
+        with pytest.raises(TypeError, match="dtype"):
+            decl.validate_field(field)
+
+    def test_multiple_validators_all_checked(self) -> None:
+        import numpy as np
+
+        from offline_particles.fields import StaticField
+        from offline_particles.kernels import FieldDataDeclaration
+
+        # YX layout: passes validate_YX_ordering but fails validate_ZYX_ordering
+        data = np.ones((5, 6), dtype=np.float64)
+        field = StaticField.from_numpy(data, ("Y", "X"), ("center", "center"))
+        decl = FieldDataDeclaration("u", np.float64, [validate_YX_ordering, validate_ZYX_ordering])
+        with pytest.raises(ValueError, match="Expected axes"):
+            decl.validate_field(field)

--- a/tests/spatial_arrays/test_array_layout.py
+++ b/tests/spatial_arrays/test_array_layout.py
@@ -1,0 +1,112 @@
+"""Tests for the ArrayLayout class."""
+
+import pytest
+
+from offline_particles.spatial_arrays import ArrayAxis, ArrayLayout, Stagger
+
+
+class TestArrayLayoutConstruction:
+    def test_3d_zyx_construction(self) -> None:
+        layout = ArrayLayout(("Z", "Y", "X"), ("center", "center", "center"))
+        assert layout.ndim == 3
+        assert layout.axes == (ArrayAxis.Z, ArrayAxis.Y, ArrayAxis.X)
+        assert layout.staggers == (Stagger.CENTER, Stagger.CENTER, Stagger.CENTER)
+
+    def test_2d_yx_construction(self) -> None:
+        layout = ArrayLayout(("Y", "X"), ("left", "right"))
+        assert layout.ndim == 2
+        assert layout.axes == (ArrayAxis.Y, ArrayAxis.X)
+        assert layout.staggers == (Stagger.LEFT, Stagger.RIGHT)
+
+    def test_1d_z_construction(self) -> None:
+        layout = ArrayLayout(("Z",), ("outer",))
+        assert layout.ndim == 1
+        assert layout.axes == (ArrayAxis.Z,)
+        assert layout.staggers == (Stagger.OUTER,)
+
+    def test_accepts_enum_members_directly(self) -> None:
+        layout = ArrayLayout((ArrayAxis.Z, ArrayAxis.Y, ArrayAxis.X), (Stagger.CENTER, Stagger.LEFT, Stagger.RIGHT))
+        assert layout.axes == (ArrayAxis.Z, ArrayAxis.Y, ArrayAxis.X)
+        assert layout.staggers == (Stagger.CENTER, Stagger.LEFT, Stagger.RIGHT)
+
+    def test_aliases_resolve_to_canonical_axes(self) -> None:
+        layout = ArrayLayout(("DEPTH", "LATITUDE", "LON"), ("center", "center", "center"))
+        assert layout.axes == (ArrayAxis.Z, ArrayAxis.Y, ArrayAxis.X)
+
+    def test_arbitrary_axis_ordering(self) -> None:
+        """Axes can be in any order, not just Z-Y-X."""
+        layout = ArrayLayout(("X", "Y", "Z"), ("center", "center", "center"))
+        assert layout.axes == (ArrayAxis.X, ArrayAxis.Y, ArrayAxis.Z)
+
+    def test_non_zyx_ordering_2d(self) -> None:
+        """2D layout does not have to be Y-X; Z-X is also valid."""
+        layout = ArrayLayout(("Z", "X"), ("center", "center"))
+        assert layout.axes == (ArrayAxis.Z, ArrayAxis.X)
+
+
+class TestArrayLayoutNdim:
+    def test_ndim_matches_number_of_axes(self) -> None:
+        for n_axes in range(1, 4):
+            axes = ("Z", "Y", "X")[:n_axes]
+            staggers = ("center",) * n_axes
+            layout = ArrayLayout(axes, staggers)
+            assert layout.ndim == n_axes
+
+
+class TestArrayLayoutOffsets:
+    def test_offsets_match_stagger_offsets(self) -> None:
+        layout = ArrayLayout(("Z", "Y", "X"), ("center", "left", "right"))
+        assert layout.offsets == (Stagger.CENTER.offset, Stagger.LEFT.offset, Stagger.RIGHT.offset)
+
+    def test_center_stagger_gives_zero_offset(self) -> None:
+        layout = ArrayLayout(("Z",), ("center",))
+        assert layout.offsets == (0.0,)
+
+    def test_all_stagger_types_produce_correct_offsets(self) -> None:
+        for stagger in Stagger:
+            layout = ArrayLayout(("Z",), (stagger,))
+            assert layout.offsets == (stagger.offset,)
+
+
+class TestArrayLayoutImmutability:
+    def test_cannot_set_attribute(self) -> None:
+        layout = ArrayLayout(("Z", "Y", "X"), ("center", "center", "center"))
+        with pytest.raises(AttributeError):
+            layout.ndim = 2  # type: ignore[misc]
+
+    def test_cannot_set_axes(self) -> None:
+        layout = ArrayLayout(("Z", "Y", "X"), ("center", "center", "center"))
+        with pytest.raises(AttributeError):
+            layout.axes = (ArrayAxis.Y, ArrayAxis.X)  # type: ignore[misc]
+
+    def test_cannot_delete_attribute(self) -> None:
+        layout = ArrayLayout(("Z", "Y", "X"), ("center", "center", "center"))
+        with pytest.raises(AttributeError):
+            del layout.ndim  # type: ignore[misc]
+
+
+class TestArrayLayoutValidation:
+    def test_mismatched_axes_and_staggers_lengths_raise(self) -> None:
+        with pytest.raises(ValueError, match="Number of axes and staggers must match"):
+            ArrayLayout(("Z", "Y"), ("center",))
+
+    def test_duplicate_axes_raise(self) -> None:
+        with pytest.raises(ValueError, match="Axes must be unique"):
+            ArrayLayout(("Z", "Z"), ("center", "center"))
+
+    def test_duplicate_axes_raise_3d(self) -> None:
+        with pytest.raises(ValueError, match="Axes must be unique"):
+            ArrayLayout(("Z", "Y", "Z"), ("center", "center", "center"))
+
+    def test_alias_duplicate_axes_raise(self) -> None:
+        """Mapping two dims to the same canonical axis should raise."""
+        with pytest.raises(ValueError, match="Axes must be unique"):
+            ArrayLayout(("Z", "DEPTH"), ("center", "center"))
+
+    def test_invalid_axis_string_raises(self) -> None:
+        with pytest.raises(ValueError):
+            ArrayLayout(("INVALID",), ("center",))
+
+    def test_invalid_stagger_string_raises(self) -> None:
+        with pytest.raises(ValueError):
+            ArrayLayout(("Z",), ("invalid_stagger",))

--- a/tests/spatial_arrays/test_stagger.py
+++ b/tests/spatial_arrays/test_stagger.py
@@ -1,74 +1,24 @@
 from offline_particles.spatial_arrays import (
-    ACTIVE_STAGGERS,
     ALL_STAGGERS,
     CENTERED_STAGGERS,
-    INACTIVE_STAGGERS,
-    INVARIANT_STAGGERS,
     ON_FACE_STAGGERS,
     Stagger,
 )
 
 
 def test_stagger_location_is_exclusive() -> None:
-    # Every stagger must be classified as exactly one of: invariant, on-face, or at-center.
+    # Every stagger must be classified as exactly one of: on-face, or at-center.
     for stagger in Stagger:
-        flags = (stagger.is_invariant, stagger.on_face, stagger.at_center)
+        flags = (stagger.on_face, stagger.at_center)
         assert sum(flags) == 1
 
 
-def test_stagger_is_active_and_is_invariant_are_exclusive() -> None:
-    # Exactly one of is_active or is_invariant must be true.
-    for stagger in Stagger:
-        assert stagger.is_active != stagger.is_invariant
-
-
-def test_stagger_offset_is_float_if_active() -> None:
-    # Active staggers should always provide a float offset.
-    for stagger in Stagger:
-        if stagger.is_active:
-            assert isinstance(stagger.offset, float)
-
-
-def test_stagger_offset_is_none_if_inactive() -> None:
-    # Inactive (invariant) staggers have no offset.
-    for stagger in Stagger:
-        if not stagger.is_active:
-            assert stagger.offset is None
-
-
-def test_stagger_expected_size_is_int_if_active() -> None:
-    # Active staggers should produce an integer expected size.
-    for stagger in Stagger:
-        if stagger.is_active:
-            assert isinstance(stagger.expected_size(7), int)
-
-
-def test_stagger_expected_size_is_none_if_invariant() -> None:
-    # Invariant staggers should not define an expected size.
-    for stagger in Stagger:
-        if stagger.is_invariant:
-            assert stagger.expected_size(7) is None
-
-
 def test_location_stagger_sets_union_to_all_staggers() -> None:
-    # Centered, on-face, and invariant categories should cover all stagger values.
-    union = CENTERED_STAGGERS | ON_FACE_STAGGERS | INVARIANT_STAGGERS
+    # Centered and on-face categories should cover all stagger values.
+    union = CENTERED_STAGGERS | ON_FACE_STAGGERS
     assert union == ALL_STAGGERS
 
 
 def test_location_stagger_sets_are_pairwise_non_intersecting() -> None:
     # Category sets should be disjoint from each other.
     assert CENTERED_STAGGERS.isdisjoint(ON_FACE_STAGGERS)
-    assert CENTERED_STAGGERS.isdisjoint(INVARIANT_STAGGERS)
-    assert ON_FACE_STAGGERS.isdisjoint(INVARIANT_STAGGERS)
-
-
-def test_active_and_inactive_stagger_sets_union_to_all_staggers() -> None:
-    # Active and inactive categories should cover all staggers.
-    union = ACTIVE_STAGGERS | INACTIVE_STAGGERS
-    assert union == ALL_STAGGERS
-
-
-def test_active_and_inactive_stagger_sets_are_disjoint() -> None:
-    # Active and inactive categories should not overlap.
-    assert ACTIVE_STAGGERS.isdisjoint(INACTIVE_STAGGERS)


### PR DESCRIPTION
Major refactor to allow us to work with arbitrary ordering of spatial dimensions. 
This PR primarily concerns itself with the machinery required to work with arbitrary spatial dimensions.
Many kernels still expect arrays ordered ZYX. They can be generalised in a later PR.
I've made many changes so the tests are a bit of a mess.