### PR TITLE
Major refactor of how we specify kernel input type constraints

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,7 @@ When conducting a code review, please follow these guidelines:
 - Ensure the docstring of any modified function, method or class is up to date.
   - Ensure it accurately describes the behaviour.
   - Ensure the NumPy docstring style is strictly followed.
+  - The "Raises" section should document all exceptions raised either directly in the function/method/class or indirectly via another function/method/class defined in this code base. Exceptions raised via external libraries may be documented if appropriate.
   - Ensure the docstring is formatted in a way that is compatible with our documentation tools (Sphinx and napoleon).
   - This applies to both src and test code.
 - Require that the behaviour of any modified function, method or class is tested.
@@ -10,3 +11,4 @@ When conducting a code review, please follow these guidelines:
 - Some classes may also benefit from a `description` or `summary` property.
   - This is useful if any end user would benefit from a more detailed description of a class instance's behaviour.
   - This does not supersede a proper description of class level behaviour (i.e. behaviour that applies to all instances) in the class docstring.
+- This code base is still in development and hence breaking changes are to be expected. However, if a change has a downstream impact on another part of this code base, ensure that this is noted in the code review.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,7 +100,6 @@ def apply_kernels_module_overrides(app):
         ParticleKernel,
         ParticlePropertyDeclaration,
         ScalarDeclaration,
-        get_required_particle_property_dtypes,
     )
 
     _module = kernels_module.__name__
@@ -110,7 +109,6 @@ def apply_kernels_module_overrides(app):
         ParticleKernel,
         ParticlePropertyDeclaration,
         ScalarDeclaration,
-        get_required_particle_property_dtypes,
     ]:
         _obj.__module__ = _module
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ pydocstyle.convention = "numpy"
 extend-select = ["D", "DOC", "I"]
 ignore = [
   "D1", # Missing public docstrings
+  "DOC502", # docstring-extraneous-exception (we want to document all exceptions, even if they are raised via another function)
   "E266"
 ]
 

--- a/src/offline_particles/kernels/__init__.py
+++ b/src/offline_particles/kernels/__init__.py
@@ -28,7 +28,6 @@ from ._kernels import (
     ParticlePropertyDeclaration,
     ScalarDeclaration,
     ScalarsType,
-    get_required_particle_property_dtypes,
 )
 from .status import Status, is_active, is_inactive
 from .validation import construct_validation_kernel
@@ -45,7 +44,6 @@ __all__ = [
     "ScalarsType",
     "Status",
     "construct_validation_kernel",
-    "get_required_particle_property_dtypes",
     "input_declarations",
     "is_active",
     "is_inactive",

--- a/src/offline_particles/kernels/_kernels.py
+++ b/src/offline_particles/kernels/_kernels.py
@@ -329,6 +329,24 @@ class BoundKernel:
         scalar_bindings: Mapping[str, str] | None = None,
         field_data_bindings: Mapping[str, str] | None = None,
     ):
+        """Create a bound kernel.
+
+        Parameters
+        ----------
+        kernel : ParticleKernel
+            The kernel to bind.
+        particle_property_bindings : Mapping[str, str], optional
+            A mapping of declared particle property names to bound names. If not provided, the declared names are used as bound names.
+        scalar_bindings : Mapping[str, str], optional
+            A mapping of declared scalar names to bound names. If not provided, the declared names are used as bound names.
+        field_data_bindings : Mapping[str, str], optional
+            A mapping of declared field data names to bound names. If not provided, the declared names are used as bound names.
+
+        Raises
+        ------
+        ValueError
+            If there are unused bindings in any of the provided binding mappings.
+        """
         self._kernel = kernel
 
         # defaults for optional arguments
@@ -440,6 +458,9 @@ class BoundKernel:
         ------
         KeyError
             If the particles do not have a required particle property.
+        TypeError
+            If a particle property has a dtype that does not satisfy the declaration's dtype constraints.
+            From :meth:`~ParticlePropertyDeclaration.validate_dtype` for each particle property.
         """
         for declared_name, bound_name in self._particle_property_bindings.items():
             if bound_name not in particles:

--- a/src/offline_particles/kernels/_kernels.py
+++ b/src/offline_particles/kernels/_kernels.py
@@ -53,10 +53,6 @@ class KernelInputDeclaration:
     def _doc_string_part(self) -> str:
         return f"'{self.name}' ({self._constraint_str})"
 
-
-class ParticlePropertyDeclaration(KernelInputDeclaration):
-    """Declaration of a particle property required by a kernel."""
-
     def validate_dtype(self, dtype: type[np.generic] | np.dtype) -> None:
         """Validate that the dtype satisfies the declared constraints.
 
@@ -72,8 +68,12 @@ class ParticlePropertyDeclaration(KernelInputDeclaration):
         """
         if not any(np.issubdtype(dtype, constraint) for constraint in self.dtype_constraints):
             raise TypeError(
-                f"Kernel particle property '{self.name}' has dtype constraints `{self._constraint_str}`, but the provided dtype '{dtype}' does not satisfy these constraints."
+                f"Kernel input '{self.name}' has dtype constraints `{self._constraint_str}`, but the provided dtype '{dtype}' does not satisfy these constraints."
             )
+
+
+class ParticlePropertyDeclaration(KernelInputDeclaration):
+    """Declaration of a particle property required by a kernel."""
 
 
 class ScalarDeclaration(KernelInputDeclaration):
@@ -111,14 +111,24 @@ class FieldDataDeclaration(KernelInputDeclaration):
         Raises
         ------
         TypeError
-            If the field's dtype does not match the declaration's dtype.
+            If the field's dtype does not match the declaration's dtype or if the field does not satisfy the layout constraints.
+        ValueError
+            If the field does not satisfy the layout constraints.
         """
-        if not any(np.issubdtype(field.output_dtype, dtype) for dtype in self.dtype_constraints):
+        try:
+            self.validate_dtype(field.output_dtype)
+        except TypeError as e:
             raise TypeError(
-                f"Kernel field data '{self.name}' has dtype constraints `{self._constraint_str}`, but field has dtype '{field.output_dtype}'."
-            )
+                f"Input Field does not satisfy the dtype constraints for kernel field data '{self.name}'"
+            ) from e
+
         for validator in self._layout_validators:
-            validator(field.layout)
+            try:
+                validator(field.layout)
+            except Exception as e:
+                raise ValueError(
+                    f"Input Field does not satisfy the layout constraints for kernel field data '{self.name}'"
+                ) from e
 
     @property
     def _doc_string_part(self) -> str:

--- a/src/offline_particles/kernels/_kernels.py
+++ b/src/offline_particles/kernels/_kernels.py
@@ -11,6 +11,7 @@ import numpy as np
 import numpy.typing as npt
 
 from ..fields import Field, FieldData
+from ..particles import Particles, ParticlesView
 from ..spatial_arrays import ArrayLayout
 
 # these type aliases are manually documented in the module docstring for better formatting in the docs,
@@ -28,19 +29,52 @@ class KernelInputDeclaration:
     """Declaration of a kernel input."""
 
     name: str
-    dtype: np.dtype[np.generic]
+    dtype_constraints: tuple[type[np.generic], ...]
 
-    def __init__(self, name: str, dtype: npt.DTypeLike) -> None:
+    def __init__(self, name: str, dtype_constraints: type[np.generic] | Iterable[type[np.generic]]) -> None:
+        match dtype_constraints:
+            case type() as dtype:
+                dtypes = (dtype,)
+            case Iterable() as dtypes:
+                dtypes = tuple(dtypes)
+            case _:
+                raise TypeError("dtype_constraints must be a type or an iterable of types")
+        for dtype in dtypes:
+            if not isinstance(dtype, type) or not issubclass(dtype, np.generic):
+                raise TypeError(f"dtype_constraints must be a subtype of np.generic, got {dtype}")
+
         object.__setattr__(self, "name", name)
-        object.__setattr__(self, "dtype", np.dtype(dtype))
+        object.__setattr__(self, "dtype_constraints", dtypes)
+
+    @property
+    def _constraint_str(self) -> str:
+        return " | ".join(str(dtype) for dtype in self.dtype_constraints)
 
     @property
     def _doc_string_part(self) -> str:
-        return f"'{self.name}' ({self.dtype})"
+        return f"'{self.name}' ({self._constraint_str})"
 
 
 class ParticlePropertyDeclaration(KernelInputDeclaration):
     """Declaration of a particle property required by a kernel."""
+
+    def validate_dtype(self, dtype: type[np.generic] | np.dtype) -> None:
+        """Validate that the dtype satisfies the declared constraints.
+
+        Parameters
+        ----------
+        dtype : type[np.generic] | np.dtype
+            The dtype to validate.
+
+        Raises
+        ------
+        TypeError
+            If the dtype does not satisfy the declaration's dtype constraints.
+        """
+        if not any(np.issubdtype(dtype, constraint) for constraint in self.dtype_constraints):
+            raise TypeError(
+                f"Kernel particle property '{self.name}' has dtype constraints `{self._constraint_str}`, but the provided dtype '{dtype}' does not satisfy these constraints."
+            )
 
 
 class ScalarDeclaration(KernelInputDeclaration):
@@ -56,11 +90,16 @@ class FieldDataDeclaration(KernelInputDeclaration):
     def __init__(
         self,
         name: str,
-        dtype: npt.DTypeLike,
-        layout_validators: Iterable[LayoutValidator] = (),
+        dtype_constraints: type[np.generic] | Iterable[type[np.generic]],
+        layout_validators: LayoutValidator | Iterable[LayoutValidator] = (),
     ) -> None:
-        KernelInputDeclaration.__init__(self, name, dtype)
-        object.__setattr__(self, "_layout_validators", tuple(layout_validators))
+        if callable(layout_validators):
+            validators = (layout_validators,)
+        else:
+            validators = tuple(layout_validators)
+
+        KernelInputDeclaration.__init__(self, name, dtype_constraints)
+        object.__setattr__(self, "_layout_validators", validators)
 
     def validate_field(self, field: Field) -> None:
         """Validate that a field matches this declaration.
@@ -75,16 +114,16 @@ class FieldDataDeclaration(KernelInputDeclaration):
         TypeError
             If the field's dtype does not match the declaration's dtype.
         """
-        if field.output_dtype != self.dtype:
+        if not any(np.issubdtype(field.output_dtype, dtype) for dtype in self.dtype_constraints):
             raise TypeError(
-                f"Kernel field data '{self.name}' has dtype '{self.dtype}', but field has dtype '{field.output_dtype}'."
+                f"Kernel field data '{self.name}' has dtype constraints `{self._constraint_str}`, but field has dtype '{field.output_dtype}'."
             )
         for validator in self._layout_validators:
             validator(field.layout)
 
     @property
     def _doc_string_part(self) -> str:
-        return f"'{self.name}' ({self.dtype}) with {len(self._layout_validators)} layout validators"
+        return f"{super()._doc_string_part} with {len(self._layout_validators)} layout validators"
 
 
 class ParticleKernel:
@@ -298,10 +337,15 @@ class BoundKernel:
 
         # bind inputs defaulting to the declared names
         self._particle_property_bindings = {
-            name: particle_property_bindings.pop(name, name) for name in kernel.particle_properties
+            declared_name: particle_property_bindings.pop(declared_name, declared_name)
+            for declared_name in kernel.particle_properties
         }
-        self._scalar_bindings = {name: scalar_bindings.pop(name, name) for name in kernel.scalars}
-        self._field_data_bindings = {name: field_data_bindings.pop(name, name) for name in kernel.field_data}
+        self._scalar_bindings = {
+            declared_name: scalar_bindings.pop(declared_name, declared_name) for declared_name in kernel.scalars
+        }
+        self._field_data_bindings = {
+            declared_name: field_data_bindings.pop(declared_name, declared_name) for declared_name in kernel.field_data
+        }
 
         # error if unused bindings
         if particle_property_bindings:
@@ -321,18 +365,79 @@ class BoundKernel:
 
     @property
     def particle_property_bindings(self) -> Mapping[str, str]:
-        """The particle property bindings."""
+        """The particle property bindings.
+
+        A mapping from declared names to bound names.
+        """
         return types.MappingProxyType(self._particle_property_bindings)
 
     @property
     def scalar_bindings(self) -> Mapping[str, str]:
-        """The scalar bindings."""
+        """The scalar bindings.
+
+        A mapping from declared names to bound names.
+        """
         return types.MappingProxyType(self._scalar_bindings)
 
     @property
     def field_data_bindings(self) -> Mapping[str, str]:
-        """The field data bindings."""
+        """The field data bindings.
+
+        A mapping from declared names to bound names.
+        """
         return types.MappingProxyType(self._field_data_bindings)
+
+    @property
+    def particle_property_declarations(self) -> dict[str, ParticlePropertyDeclaration]:
+        """The particle property declarations.
+
+        A mapping from bound names to declarations.
+        """
+        return {
+            bound_name: self.kernel.particle_properties[declared_name]
+            for declared_name, bound_name in self.particle_property_bindings.items()
+        }
+
+    @property
+    def scalar_declarations(self) -> dict[str, ScalarDeclaration]:
+        """The scalar declarations.
+
+        A mapping from bound names to declarations.
+        """
+        return {
+            bound_name: self.kernel.scalars[declared_name] for declared_name, bound_name in self.scalar_bindings.items()
+        }
+
+    @property
+    def field_data_declarations(self) -> dict[str, FieldDataDeclaration]:
+        """The field data declarations.
+
+        A mapping from bound names to declarations.
+        """
+        return {
+            bound_name: self.kernel.field_data[declared_name]
+            for declared_name, bound_name in self.field_data_bindings.items()
+        }
+
+    def validate_particles(self, particles: Particles | ParticlesView) -> None:
+        """Validate that the particles have required particle properties of the correct data types.
+
+        Parameters
+        ----------
+        particles : Particles | ParticlesView
+            The particles to validate.
+
+        Raises
+        ------
+        KeyError
+            If the particles do not have a required particle property.
+        """
+        for declared_name, bound_name in self._particle_property_bindings.items():
+            if bound_name not in particles:
+                raise KeyError(f"Particle property '{bound_name}' is required but not found in the particles.")
+            # get declaration and validate dtype
+            particle_property_declaration = self._kernel.particle_properties[declared_name]
+            particle_property_declaration.validate_dtype(particles[bound_name].dtype)
 
     def rebind(
         self,
@@ -380,16 +485,16 @@ class BoundKernel:
         doc_lines = [f"Kernel Binding for {kernel}"]
 
         doc_lines.extend(_new_doc_section("Particle Property Bindings"))
-        for name, binding in self._particle_property_bindings.items():
-            doc_lines.append(f"'{binding}' → {kernel.particle_properties[name]._doc_string_part}")
+        for bound_name, declaration in self.particle_property_declarations.items():
+            doc_lines.append(f"'{bound_name}' → {declaration._doc_string_part}")
 
         doc_lines.extend(_new_doc_section("Scalar Bindings"))
-        for name, binding in self._scalar_bindings.items():
-            doc_lines.append(f"'{binding}' → {kernel.scalars[name]._doc_string_part}")
+        for bound_name, declaration in self.scalar_declarations.items():
+            doc_lines.append(f"'{bound_name}' → {declaration._doc_string_part}")
 
         doc_lines.extend(_new_doc_section("Field Data Bindings"))
-        for name, binding in self._field_data_bindings.items():
-            doc_lines.append(f"'{binding}' → {kernel.field_data[name]._doc_string_part}")
+        for bound_name, declaration in self.field_data_declarations.items():
+            doc_lines.append(f"'{bound_name}' → {declaration._doc_string_part}")
 
         return "\n".join(doc_lines)
 
@@ -438,40 +543,6 @@ class BoundKernel:
             A new BoundKernel that combines the underlying kernels and their bindings.
         """
         return self.__class__.chain(self, *others)
-
-
-def get_required_particle_property_dtypes(*bound_kernels: BoundKernel) -> Mapping[str, np.dtype]:
-    """Get the required particle properties types from bound kernels.
-
-    Parameters
-    ----------
-    *bound_kernels : BoundKernel
-        The bound kernels to get the required particle properties from.
-
-    Returns
-    -------
-    Mapping[str, np.dtype]
-        A mapping of bound particle property names to their dtypes.
-
-    Raises
-    ------
-    ValueError
-        If there are conflicting dtype declarations for the same particle property name.
-    """
-    required: dict[str, np.dtype] = {}
-    for kb in bound_kernels:
-        for name in kb.particle_property_bindings:
-            binding = kb.particle_property_bindings[name]
-            particle_property = kb.kernel.particle_properties[name]
-            if binding in required:
-                if required[binding] != particle_property.dtype:
-                    raise ValueError(
-                        f"Conflicting dtype declarations for particle property '{binding}': "
-                        f"{required[binding]} vs {particle_property.dtype}"
-                    )
-            else:
-                required[binding] = particle_property.dtype
-    return types.MappingProxyType(required)
 
 
 # helper functions

--- a/src/offline_particles/kernels/_kernels.py
+++ b/src/offline_particles/kernels/_kernels.py
@@ -111,7 +111,7 @@ class FieldDataDeclaration(KernelInputDeclaration):
         Raises
         ------
         TypeError
-            If the field's dtype does not match the declaration's dtype or if the field does not satisfy the layout constraints.
+            If the field's dtype does not match the declaration's dtype.
         ValueError
             If the field does not satisfy the layout constraints.
         """

--- a/src/offline_particles/kernels/_kernels.py
+++ b/src/offline_particles/kernels/_kernels.py
@@ -11,7 +11,6 @@ import numpy as np
 import numpy.typing as npt
 
 from ..fields import Field, FieldData
-from ..particles import Particles, ParticlesView
 from ..spatial_arrays import ArrayLayout
 
 # these type aliases are manually documented in the module docstring for better formatting in the docs,
@@ -123,7 +122,7 @@ class FieldDataDeclaration(KernelInputDeclaration):
 
     @property
     def _doc_string_part(self) -> str:
-        return f"{super()._doc_string_part} with {len(self._layout_validators)} layout validators"
+        return f"'{self.name}' ({self._constraint_str}) with {len(self._layout_validators)} layout validators"
 
 
 class ParticleKernel:
@@ -419,13 +418,13 @@ class BoundKernel:
             for declared_name, bound_name in self.field_data_bindings.items()
         }
 
-    def validate_particles(self, particles: Particles | ParticlesView) -> None:
+    def validate_particles(self, particles: Mapping[str, npt.NDArray]) -> None:
         """Validate that the particles have required particle properties of the correct data types.
 
         Parameters
         ----------
-        particles : Particles | ParticlesView
-            The particles to validate.
+        particles : Mapping[str, npt.NDArray]
+            A mapping from particle property names to their corresponding arrays.
 
         Raises
         ------

--- a/src/offline_particles/kernels/base/__init__.py
+++ b/src/offline_particles/kernels/base/__init__.py
@@ -37,8 +37,8 @@ def construct_copy_property_kernel(
     BoundKernel
         A bound kernel that copies the source property to the destination property.
     """
-    source_declaration = ParticlePropertyDeclaration("source", np.dtype(dtype))
-    destination_declaration = ParticlePropertyDeclaration("destination", np.dtype(dtype))
+    source_declaration = ParticlePropertyDeclaration("source", np.dtype(dtype).type)
+    destination_declaration = ParticlePropertyDeclaration("destination", np.dtype(dtype).type)
 
     kernel = ParticleKernel(
         copy_property,
@@ -79,8 +79,8 @@ def construct_add_property_kernel(
     BoundKernel
         A bound kernel that adds the source property to the destination property.
     """
-    source_declaration = ParticlePropertyDeclaration("source", np.dtype(dtype))
-    destination_declaration = ParticlePropertyDeclaration("destination", np.dtype(dtype))
+    source_declaration = ParticlePropertyDeclaration("source", np.dtype(dtype).type)
+    destination_declaration = ParticlePropertyDeclaration("destination", np.dtype(dtype).type)
 
     kernel = ParticleKernel(
         add_property,
@@ -121,8 +121,8 @@ def construct_subtract_property_kernel(
     BoundKernel
         A bound kernel that subtracts the source property from the destination property.
     """
-    source_declaration = ParticlePropertyDeclaration("source", np.dtype(dtype))
-    destination_declaration = ParticlePropertyDeclaration("destination", np.dtype(dtype))
+    source_declaration = ParticlePropertyDeclaration("source", np.dtype(dtype).type)
+    destination_declaration = ParticlePropertyDeclaration("destination", np.dtype(dtype).type)
 
     kernel = ParticleKernel(
         subtract_property,
@@ -163,8 +163,8 @@ def construct_multiply_property_kernel(
     BoundKernel
         A bound kernel that multiplies the destination property by the source property.
     """
-    source_declaration = ParticlePropertyDeclaration("source", np.dtype(dtype))
-    destination_declaration = ParticlePropertyDeclaration("destination", np.dtype(dtype))
+    source_declaration = ParticlePropertyDeclaration("source", np.dtype(dtype).type)
+    destination_declaration = ParticlePropertyDeclaration("destination", np.dtype(dtype).type)
 
     kernel = ParticleKernel(
         multiply_property,
@@ -205,8 +205,8 @@ def construct_divide_property_kernel(
     BoundKernel
         A bound kernel that divides the destination property by the source property.
     """
-    source_declaration = ParticlePropertyDeclaration("source", np.dtype(dtype))
-    destination_declaration = ParticlePropertyDeclaration("destination", np.dtype(dtype))
+    source_declaration = ParticlePropertyDeclaration("source", np.dtype(dtype).type)
+    destination_declaration = ParticlePropertyDeclaration("destination", np.dtype(dtype).type)
 
     kernel = ParticleKernel(
         divide_property,

--- a/src/offline_particles/kernels/input_declarations.py
+++ b/src/offline_particles/kernels/input_declarations.py
@@ -30,4 +30,4 @@ def construct_time_declaration(time_dtype: npt.DTypeLike) -> ScalarDeclaration:
     ScalarDeclaration
         A ScalarDeclaration for the simulation time.
     """
-    return ScalarDeclaration("_time", np.dtype(time_dtype))
+    return ScalarDeclaration("_time", np.dtype(time_dtype).type)

--- a/src/offline_particles/kernels/interpolation/_kernel_constructors.py
+++ b/src/offline_particles/kernels/interpolation/_kernel_constructors.py
@@ -80,11 +80,11 @@ def construct_1D_interpolation_kernel(
     validator = ordering_validator_factory((axis,))
 
     # get types for field and output
-    field_dtype = np.dtype(field_dtype)
+    field_dtype = np.dtype(field_dtype).type
     if output_dtype is None:
         output_dtype = field_dtype
     else:
-        output_dtype = np.dtype(output_dtype)
+        output_dtype = np.dtype(output_dtype).type
 
     # select kernel function implementation based on accumulate flag
     kernel_function_impl = lagrange2N_1D_factory(N, accumulate)
@@ -184,11 +184,11 @@ def construct_2D_interpolation_kernel(
     validator = ordering_validator_factory((axis_0, axis_1))
 
     # get types for field and output
-    field_dtype = np.dtype(field_dtype)
+    field_dtype = np.dtype(field_dtype).type
     if output_dtype is None:
         output_dtype = field_dtype
     else:
-        output_dtype = np.dtype(output_dtype)
+        output_dtype = np.dtype(output_dtype).type
 
     # select kernel function implementation
     kernel_function_impl = lagrange2N_2D_factory(N, accumulate)
@@ -294,11 +294,11 @@ def construct_3D_interpolation_kernel(
     validator = ordering_validator_factory((axis_0, axis_1, axis_2))
 
     # get types for field and output
-    field_dtype = np.dtype(field_dtype)
+    field_dtype = np.dtype(field_dtype).type
     if output_dtype is None:
         output_dtype = field_dtype
     else:
-        output_dtype = np.dtype(output_dtype)
+        output_dtype = np.dtype(output_dtype).type
 
     # select kernel function implementation
     kernel_function_impl = lagrange2N_3D_factory(N, accumulate)

--- a/src/offline_particles/kernels/relaxation/_relaxation_kernels_constant_coefficient.py
+++ b/src/offline_particles/kernels/relaxation/_relaxation_kernels_constant_coefficient.py
@@ -84,16 +84,15 @@ def construct_relaxation_kernel_constant_coefficient_constant_target(
     ValueError
         If the form is not "linear" or "quadratic".
     """
-    dtype = np.dtype(dtype)
-    dtype_constructor = dtype.type
+    dtype = np.dtype(dtype).type
 
     if form == "linear":
         kernel_function_impl = _linear_relaxation_constant_coefficient_constant_target(
-            dtype_constructor(relaxation_coefficient), dtype_constructor(target)
+            dtype(relaxation_coefficient), dtype(target)
         )
     elif form == "quadratic":
         kernel_function_impl = _quadratic_relaxation_constant_coefficient_constant_target(
-            dtype_constructor(relaxation_coefficient), dtype_constructor(target)
+            dtype(relaxation_coefficient), dtype(target)
         )
     else:
         raise ValueError(f"Invalid form: {form}. Must be 'linear' or 'quadratic'.")
@@ -162,17 +161,12 @@ def construct_relaxation_kernel_constant_coefficient_property_target(
     ValueError
         If the form is not "linear" or "quadratic".
     """
-    dtype = np.dtype(dtype)
-    dtype_constructor = dtype.type
+    dtype = np.dtype(dtype).type
 
     if form == "linear":
-        kernel_function_impl = _linear_relaxation_constant_coefficient_property_target(
-            dtype_constructor(relaxation_coefficient)
-        )
+        kernel_function_impl = _linear_relaxation_constant_coefficient_property_target(dtype(relaxation_coefficient))
     elif form == "quadratic":
-        kernel_function_impl = _quadratic_relaxation_constant_coefficient_property_target(
-            dtype_constructor(relaxation_coefficient)
-        )
+        kernel_function_impl = _quadratic_relaxation_constant_coefficient_property_target(dtype(relaxation_coefficient))
     else:
         raise ValueError(f"Invalid form: {form}. Must be 'linear' or 'quadratic'.")
 
@@ -243,17 +237,12 @@ def construct_relaxation_kernel_constant_coefficient_scalar_target(
     ValueError
         If the form is not "linear" or "quadratic".
     """
-    dtype = np.dtype(dtype)
-    dtype_constructor = dtype.type
+    dtype = np.dtype(dtype).type
 
     if form == "linear":
-        kernel_function_impl = _linear_relaxation_constant_coefficient_scalar_target(
-            dtype_constructor(relaxation_coefficient)
-        )
+        kernel_function_impl = _linear_relaxation_constant_coefficient_scalar_target(dtype(relaxation_coefficient))
     elif form == "quadratic":
-        kernel_function_impl = _quadratic_relaxation_constant_coefficient_scalar_target(
-            dtype_constructor(relaxation_coefficient)
-        )
+        kernel_function_impl = _quadratic_relaxation_constant_coefficient_scalar_target(dtype(relaxation_coefficient))
     else:
         raise ValueError(f"Invalid form: {form}. Must be 'linear' or 'quadratic'.")
 
@@ -476,40 +465,39 @@ def construct_relaxation_kernel_constant_coefficient_field_target(
     ValueError
         If the form is not "linear" or "quadratic", or if the array layout is not supported.
     """
-    dtype = np.dtype(dtype)
-    dtype_constructor = dtype.type
+    dtype = np.dtype(dtype).type
 
     match form, array_layout.axes:
         # 1D field target
         case "linear", (axis0,):
             kernel_function_impl = _linear_relaxation_constant_coefficient_1D_field_target(
-                dtype_constructor(relaxation_coefficient), interpolation_half_width
+                dtype(relaxation_coefficient), interpolation_half_width
             )
             index_declarations = [_INDEX_DECLARATION_MAPPING[axis0]]
             kernel_function = _construct_1d_kernel_function(kernel_function_impl, axis0)
         case "quadratic", (axis0,):
             kernel_function_impl = _quadratic_relaxation_constant_coefficient_1D_field_target(
-                dtype_constructor(relaxation_coefficient), interpolation_half_width
+                dtype(relaxation_coefficient), interpolation_half_width
             )
             index_declarations = [_INDEX_DECLARATION_MAPPING[axis0]]
             kernel_function = _construct_1d_kernel_function(kernel_function_impl, axis0)
         # 2D field target
         case "linear", (axis0, axis1):
             kernel_function_impl = _linear_relaxation_constant_coefficient_2D_field_target(
-                dtype_constructor(relaxation_coefficient), interpolation_half_width
+                dtype(relaxation_coefficient), interpolation_half_width
             )
             index_declarations = [_INDEX_DECLARATION_MAPPING[axis0], _INDEX_DECLARATION_MAPPING[axis1]]
             kernel_function = _construct_2d_kernel_function(kernel_function_impl, axis0, axis1)
         case "quadratic", (axis0, axis1):
             kernel_function_impl = _quadratic_relaxation_constant_coefficient_2D_field_target(
-                dtype_constructor(relaxation_coefficient), interpolation_half_width
+                dtype(relaxation_coefficient), interpolation_half_width
             )
             index_declarations = [_INDEX_DECLARATION_MAPPING[axis0], _INDEX_DECLARATION_MAPPING[axis1]]
             kernel_function = _construct_2d_kernel_function(kernel_function_impl, axis0, axis1)
         # 3D field target
         case "linear", (axis0, axis1, axis2):
             kernel_function_impl = _linear_relaxation_constant_coefficient_3D_field_target(
-                dtype_constructor(relaxation_coefficient), interpolation_half_width
+                dtype(relaxation_coefficient), interpolation_half_width
             )
             index_declarations = [
                 _INDEX_DECLARATION_MAPPING[axis0],
@@ -519,7 +507,7 @@ def construct_relaxation_kernel_constant_coefficient_field_target(
             kernel_function = _construct_3d_kernel_function(kernel_function_impl, axis0, axis1, axis2)
         case "quadratic", (axis0, axis1, axis2):
             kernel_function_impl = _quadratic_relaxation_constant_coefficient_3D_field_target(
-                dtype_constructor(relaxation_coefficient), interpolation_half_width
+                dtype(relaxation_coefficient), interpolation_half_width
             )
             index_declarations = [
                 _INDEX_DECLARATION_MAPPING[axis0],

--- a/src/offline_particles/kernels/relaxation/_relaxation_kernels_property_coefficient.py
+++ b/src/offline_particles/kernels/relaxation/_relaxation_kernels_property_coefficient.py
@@ -82,13 +82,12 @@ def construct_relaxation_kernel_property_coefficient_constant_target(
     ValueError
         If the form is not "linear" or "quadratic".
     """
-    dtype = np.dtype(dtype)
-    dtype_constructor = dtype.type
+    dtype = np.dtype(dtype).type
 
     if form == "linear":
-        kernel_function_impl = _linear_relaxation_property_coefficient_constant_target(dtype_constructor(target))
+        kernel_function_impl = _linear_relaxation_property_coefficient_constant_target(dtype(target))
     elif form == "quadratic":
-        kernel_function_impl = _quadratic_relaxation_property_coefficient_constant_target(dtype_constructor(target))
+        kernel_function_impl = _quadratic_relaxation_property_coefficient_constant_target(dtype(target))
     else:
         raise ValueError(f"Invalid form: {form}. Must be 'linear' or 'quadratic'.")
 
@@ -157,7 +156,7 @@ def construct_relaxation_kernel_property_coefficient_property_target(
     ValueError
         If the form is not "linear" or "quadratic".
     """
-    dtype = np.dtype(dtype)
+    dtype = np.dtype(dtype).type
 
     if form == "linear":
         kernel_function_impl = _linear_relaxation_property_coefficient_property_target()
@@ -234,7 +233,7 @@ def construct_relaxation_kernel_property_coefficient_scalar_target(
     ValueError
         If the form is not "linear" or "quadratic".
     """
-    dtype = np.dtype(dtype)
+    dtype = np.dtype(dtype).type
 
     if form == "linear":
         kernel_function_impl = _linear_relaxation_property_coefficient_scalar_target()
@@ -468,7 +467,7 @@ def construct_relaxation_kernel_property_coefficient_field_target(
     ValueError
         If the form is not "linear" or "quadratic", or if the array layout is not supported.
     """
-    dtype = np.dtype(dtype)
+    dtype = np.dtype(dtype).type
 
     match form, array_layout.axes:
         # 1D field target

--- a/src/offline_particles/kernels/relaxation/_relaxation_kernels_scalar_coefficient.py
+++ b/src/offline_particles/kernels/relaxation/_relaxation_kernels_scalar_coefficient.py
@@ -82,13 +82,12 @@ def construct_relaxation_kernel_scalar_coefficient_constant_target(
     ValueError
         If the form is not "linear" or "quadratic".
     """
-    dtype = np.dtype(dtype)
-    dtype_constructor = dtype.type
+    dtype = np.dtype(dtype).type
 
     if form == "linear":
-        kernel_function_impl = _linear_relaxation_scalar_coefficient_constant_target(dtype_constructor(target))
+        kernel_function_impl = _linear_relaxation_scalar_coefficient_constant_target(dtype(target))
     elif form == "quadratic":
-        kernel_function_impl = _quadratic_relaxation_scalar_coefficient_constant_target(dtype_constructor(target))
+        kernel_function_impl = _quadratic_relaxation_scalar_coefficient_constant_target(dtype(target))
     else:
         raise ValueError(f"Invalid form: {form}. Must be 'linear' or 'quadratic'.")
 
@@ -161,7 +160,7 @@ def construct_relaxation_kernel_scalar_coefficient_property_target(
     ValueError
         If the form is not "linear" or "quadratic".
     """
-    dtype = np.dtype(dtype)
+    dtype = np.dtype(dtype).type
 
     if form == "linear":
         kernel_function_impl = _linear_relaxation_scalar_coefficient_property_target()
@@ -242,7 +241,7 @@ def construct_relaxation_kernel_scalar_coefficient_scalar_target(
     ValueError
         If the form is not "linear" or "quadratic".
     """
-    dtype = np.dtype(dtype)
+    dtype = np.dtype(dtype).type
 
     if form == "linear":
         kernel_function_impl = _linear_relaxation_scalar_coefficient_scalar_target()
@@ -476,7 +475,7 @@ def construct_relaxation_kernel_scalar_coefficient_field_target(
     ValueError
         If the form is not "linear" or "quadratic", or if the array layout is not supported.
     """
-    dtype = np.dtype(dtype)
+    dtype = np.dtype(dtype).type
 
     match form, array_layout.axes:
         # 1D field target

--- a/src/offline_particles/kernels/timed_activation/__init__.py
+++ b/src/offline_particles/kernels/timed_activation/__init__.py
@@ -36,7 +36,7 @@ def construct_activate_released_particles_kernel(
     BoundKernel
         A bound kernel that activates particles at the given release time.
     """
-    release_time_declaration = ParticlePropertyDeclaration("release_time", np.dtype(dtype))
+    release_time_declaration = ParticlePropertyDeclaration("release_time", np.dtype(dtype).type)
 
     kernel = ParticleKernel(
         activate_released_particles,
@@ -77,7 +77,7 @@ def construct_deactivate_retired_particles_kernel(
     BoundKernel
         A bound kernel that deactivates particles at the given retirement time.
     """
-    retirement_time_declaration = ParticlePropertyDeclaration("retirement_time", np.dtype(dtype))
+    retirement_time_declaration = ParticlePropertyDeclaration("retirement_time", np.dtype(dtype).type)
 
     kernel = ParticleKernel(
         deactivate_retired_particles,

--- a/src/offline_particles/kernels/timestepping/adams_bashforth.py
+++ b/src/offline_particles/kernels/timestepping/adams_bashforth.py
@@ -16,7 +16,7 @@ from ._adams_bashforth import ab2_update, ab3_update, ab_bump_status, ab_initial
 
 
 # particle property declarations for Adams-Bashforth
-def _particle_property_declarations(dtype: np.inexact, order: int) -> list[ParticlePropertyDeclaration]:
+def _particle_property_declarations(dtype: type[np.inexact], order: int) -> list[ParticlePropertyDeclaration]:
     """Create particle property declarations for Adams-Bashforth kernels.
 
     Parameters
@@ -31,10 +31,10 @@ def _particle_property_declarations(dtype: np.inexact, order: int) -> list[Parti
     list[ParticlePropertyDeclaration]
         List of particle property declarations for the property plus its current and previous tendencies.
     """
-    prop_declaration = ParticlePropertyDeclaration("prop", np.dtype(dtype))
-    dprop_0_declaration = ParticlePropertyDeclaration("dprop_0", np.dtype(dtype))
-    dprop_1_declaration = ParticlePropertyDeclaration("dprop_1", np.dtype(dtype))
-    dprop_2_declaration = ParticlePropertyDeclaration("dprop_2", np.dtype(dtype))
+    prop_declaration = ParticlePropertyDeclaration("prop", dtype)
+    dprop_0_declaration = ParticlePropertyDeclaration("dprop_0", dtype)
+    dprop_1_declaration = ParticlePropertyDeclaration("dprop_1", dtype)
+    dprop_2_declaration = ParticlePropertyDeclaration("dprop_2", dtype)
 
     declarations = [
         STATUS_DECLARATION,

--- a/src/offline_particles/output/_interpolation.py
+++ b/src/offline_particles/output/_interpolation.py
@@ -92,6 +92,6 @@ def interpolate_fields(
             case _:
                 raise ValueError(f"Field '{var}' has unsupported number of axes: {len(field.axes)}")
 
-        outputs[var] = Output(particle_property, kernel)
+        outputs[var] = Output(particle_property, dtype=dtype, kernels=(kernel,))
 
     return outputs

--- a/src/offline_particles/output/_output.py
+++ b/src/offline_particles/output/_output.py
@@ -12,71 +12,48 @@ import numpy as np
 import numpy.typing as npt
 
 from ..events import Event, SimulationState
-from ..kernels import BoundKernel, ParticlePropertyDeclaration, get_required_particle_property_dtypes
+from ..kernels import BoundKernel
 
 
 @dataclasses.dataclass(frozen=True, slots=True, init=False)
 class Output:
     """Class defining a single output."""
 
-    particle_property: ParticlePropertyDeclaration
+    particle_property: str
+    dtype: np.dtype
     kernels: tuple[BoundKernel, ...]
     attrs: dict[str, Any]
 
     def __init__(
         self,
-        particle_property_name: str,
-        *kernels: BoundKernel,
-        dtype: npt.DTypeLike | None = None,
+        particle_property: str,
+        dtype: npt.DTypeLike = np.float64,
+        kernels: Iterable[BoundKernel] = (),
         **attrs: Any,
     ) -> None:
         """Initialize the Output.
 
         Parameters
         ----------
-        particle_property_name : str
-            The name of the particle property to output.
-        *kernels : BoundKernel
-            The kernels required to compute the output.
+        particle_property : str
+            The particle property to output.
         dtype : npt.DTypeLike, optional
             The data type of the output.
+        kernels : Iterable[BoundKernel], optional
+            The kernels required to compute the output.
         **attrs : Any
             Additional attributes for the output.
 
-        Raises
-        ------
-        ValueError
-            If the specified dtype is incompatible with the required dtype from the kernels.
+        Notes
+        -----
+        The output will be computed using the specified kernels, which are called immediately prior to the output being written.
+        The output dtype does not necessarily need to match the dtype of the particle property.
+        It is the responsibility of the output writer to convert the computed values to the appropriate dtype or error if the conversion is not possible.
         """
-        kernel_particle_property_dtypes = get_required_particle_property_dtypes(*kernels)
-
-        # case 1: the particle property is already defined by the kernels
-        if particle_property_name in kernel_particle_property_dtypes:
-            particle_property_dtype = kernel_particle_property_dtypes[particle_property_name]
-            # Check dtype compatibility
-            if dtype is not None and np.dtype(dtype) != particle_property_dtype:
-                raise ValueError(
-                    f"Output particle property '{particle_property_name}' has dtype "
-                    f"{dtype}, but a different dtype {particle_property_dtype} is required by the kernels."
-                )
-        # case 2: the particle property not required by kernels
-        else:
-            # default value for dtype
-            if dtype is None:
-                dtype = np.float64
-            particle_property_dtype = np.dtype(dtype)
-        particle_property = ParticlePropertyDeclaration(particle_property_name, particle_property_dtype)
-
         object.__setattr__(self, "particle_property", particle_property)
-        object.__setattr__(self, "kernels", kernels)
+        object.__setattr__(self, "dtype", np.dtype(dtype))
+        object.__setattr__(self, "kernels", tuple(kernels))
         object.__setattr__(self, "attrs", dict(attrs))
-
-    @property
-    def required_property_dtypes(self) -> Mapping[str, np.dtype]:
-        """Get the particle properties dtypes required by the output."""
-        required_property_dtypes = {self.particle_property.name: self.particle_property.dtype}
-        required_property_dtypes.update(get_required_particle_property_dtypes(*self.kernels))
-        return types.MappingProxyType(required_property_dtypes)
 
 
 class TwoKeyDict[OT, IT, VT](collections.abc.MutableMapping[tuple[OT, IT], VT]):

--- a/src/offline_particles/output/_zarr_writer.py
+++ b/src/offline_particles/output/_zarr_writer.py
@@ -46,11 +46,18 @@ class ZarrOutputWriter(AbstractOutputWriter):
     ) -> None:
         """Initialize the Zarr output writer.
 
-        Args:
-            store: The Zarr store to write to.
-            time_arrays: A dictionary mapping particle sets to Zarr arrays for time output.
-            outputs: A two-key mapping from particle set names and output names to ZarrOutputArrays for time-dependent outputs.
-            static_outputs: A two-key mapping from particle set names and static output names to ZarrOutputArrays for static outputs.
+        Parameters
+        ----------
+        name : str
+            The name of the output writer.
+        store : zarr.storage.StoreLike
+            The Zarr store to write to.
+        time_arrays : Mapping[str, zarr.Array]
+            A dictionary mapping particle sets to Zarr arrays for time output.
+        outputs : TwoKeyDict[str, str, ZarrOutputArray]
+            A two-key mapping from particle set names and output names to ZarrOutputArrays for time-dependent outputs.
+        static_outputs : TwoKeyDict[str, str, ZarrOutputArray]
+            A two-key mapping from particle set names and static output names to ZarrOutputArrays for static outputs.
         """
         self._name = name
         self._store = store
@@ -133,12 +140,12 @@ class ZarrOutputWriter(AbstractOutputWriter):
         zarr_output_array = self._outputs[key]
         output = zarr_output_array.output
         array = zarr_output_array.array
-        property_name = output.particle_property.name
+        property_property = output.particle_property
 
         # write output
         time_size, particle_size = array.shape
         array.resize((time_size + 1, particle_size))
-        array[-1, :] = state.particles[particle_set][property_name]
+        array[-1, :] = state.particles[particle_set][property_property]
 
     def write_static_output(self, particle_set: str, name: str, state: SimulationState) -> None:
         """Write a static (time-independent) output variable once.
@@ -168,9 +175,9 @@ class ZarrOutputWriter(AbstractOutputWriter):
         zarr_output_array = self._static_outputs[key]
         output = zarr_output_array.output
         array = zarr_output_array.array
-        property_name = output.particle_property.name
+        property_property = output.particle_property
 
-        array[:] = state.particles[particle_set][property_name]
+        array[:] = state.particles[particle_set][property_property]
 
     def finalise_write_round(self, state: SimulationState) -> None:
         """Confirm that all outputs have been written for the current round and then increments the count.
@@ -222,15 +229,22 @@ class ZarrOutputBuilder(AbstractOutputWriterBuilder):
     ) -> None:
         """Initialize the Zarr output writer builder.
 
-        Args:
-            store: The Zarr store to write to.
-
-        Keywords:
-            chunksize: The chunk size for the particle dimension.
-            time_name: The name of the time output array.
-            overwrite: Whether to overwrite existing data in the store.
-            array_kwargs: Default keyword arguments passed to Zarr.create_array for all outputs.
-            time_array_kwargs: Keyword arguments passed, in addition to array_kwargs, to Zarr.create_array for the time array.
+        Parameters
+        ----------
+        name : str
+            The name of the output writer to build.
+        store : zarr.storage.StoreLike
+            The Zarr store to write to.
+        chunksize : int, optional
+            The chunk size for the particle dimension.
+        time_name : str, optional
+            The name of the time output array.
+        overwrite : bool, optional
+            Whether to overwrite existing data in the store.
+        array_kwargs : dict[str, Any] | None, optional
+            Default keyword arguments passed to Zarr.create_array for all outputs.
+        time_array_kwargs : dict[str, Any] | None, optional
+            Keyword arguments passed, in addition to array_kwargs, to Zarr.create_array for the time array.
         """
         self._name = name
         self._store = store
@@ -477,7 +491,7 @@ class ZarrOutputBuilder(AbstractOutputWriterBuilder):
             self._store,
             name=f"{particle_set}/{name}",
             shape=shape,
-            dtype=output.particle_property.dtype,
+            dtype=output.dtype,
             chunks=chunks,
             attributes=output.attrs,
             dimension_names=(self._time_name, particle_set),
@@ -518,7 +532,7 @@ class ZarrOutputBuilder(AbstractOutputWriterBuilder):
             self._store,
             name=f"{particle_set}/{name}",
             shape=shape,
-            dtype=output.particle_property.dtype,
+            dtype=output.dtype,
             chunks=chunks,
             attributes=output.attrs,
             dimension_names=(particle_set,),

--- a/src/offline_particles/output/_zarr_writer.py
+++ b/src/offline_particles/output/_zarr_writer.py
@@ -140,12 +140,12 @@ class ZarrOutputWriter(AbstractOutputWriter):
         zarr_output_array = self._outputs[key]
         output = zarr_output_array.output
         array = zarr_output_array.array
-        property_property = output.particle_property
+        particle_property = output.particle_property
 
         # write output
         time_size, particle_size = array.shape
         array.resize((time_size + 1, particle_size))
-        array[-1, :] = state.particles[particle_set][property_property]
+        array[-1, :] = state.particles[particle_set][particle_property]
 
     def write_static_output(self, particle_set: str, name: str, state: SimulationState) -> None:
         """Write a static (time-independent) output variable once.
@@ -175,9 +175,9 @@ class ZarrOutputWriter(AbstractOutputWriter):
         zarr_output_array = self._static_outputs[key]
         output = zarr_output_array.output
         array = zarr_output_array.array
-        property_property = output.particle_property
+        particle_property = output.particle_property
 
-        array[:] = state.particles[particle_set][property_property]
+        array[:] = state.particles[particle_set][particle_property]
 
     def finalise_write_round(self, state: SimulationState) -> None:
         """Confirm that all outputs have been written for the current round and then increments the count.

--- a/src/offline_particles/particles.py
+++ b/src/offline_particles/particles.py
@@ -6,6 +6,8 @@ from collections.abc import Mapping
 import numpy as np
 import numpy.typing as npt
 
+from .kernels import BoundKernel, ParticlePropertyDeclaration
+
 
 class _FrozenArrayMapping:
     """A mapping-like object that holds equi-shaped arrays and prevents modification."""
@@ -44,6 +46,9 @@ class _FrozenArrayMapping:
 
     def __getitem__(self, name: str) -> npt.NDArray:
         return object.__getattribute__(self, "_arrays")[name]
+
+    def __contains__(self, name: str) -> bool:
+        return name in object.__getattribute__(self, "_arrays")
 
     @property
     def shape(self) -> tuple[int, ...]:
@@ -88,7 +93,7 @@ class Particles(_FrozenArrayMapping):
 
         Args:
             nparticles: The number of particles.
-            **properties: Particle property declarations.
+            **bound_property_dtypes: The bound property dtypes.
         """
         object.__setattr__(self, "_length", nparticles)
         arrays = {binding: np.zeros((nparticles,), dtype=dtype) for binding, dtype in bound_property_dtypes.items()}
@@ -97,6 +102,49 @@ class Particles(_FrozenArrayMapping):
 
     def __len__(self) -> int:
         return object.__getattribute__(self, "_length")
+
+    @classmethod
+    def build_from_kernels(
+        cls, nparticles: int, specified_dtypes: Mapping[str, npt.DTypeLike], kernels: list[BoundKernel]
+    ) -> "Particles":
+        """Initialize a Particles object from a list of particle property declarations.
+
+        Parameters
+        ----------
+        nparticles : int
+            The number of particles.
+        specified_dtypes : Mapping[str, npt.DTypeLike]
+            The specified dtypes for the particle properties.
+        kernels : list[BoundKernel]
+            The bound kernels to use for initializing the particles.
+
+        Returns
+        -------
+        Particles
+            A Particles object satisfying the constraints specified by the kernels.
+        """
+        # first collect all the names of the properties we need to initialize and the declarations that apply to them
+        declarations_by_binding: dict[str, list[ParticlePropertyDeclaration]] = {}
+        for kernel in kernels:
+            for name, declaration in kernel.particle_property_declarations.items():
+                decls = declarations_by_binding.setdefault(name, [])
+                decls.append(declaration)
+
+        # now, for each property, find a valid dtype that satisfies all of its declarations
+        bound_property_dtypes = {}
+        for name, declarations in declarations_by_binding.items():
+            if name in specified_dtypes:
+                # if the user specified a dtype for this property, we use it
+                dtype = np.dtype(specified_dtypes[name])
+                for declaration in declarations:
+                    declaration.validate_dtype(dtype)
+                bound_property_dtypes[name] = np.dtype(specified_dtypes[name])
+            else:
+                # otherwise, we find a valid dtype that satisfies all declarations for this property
+                bound_property_dtypes[name] = _find_valid_particle_property_dtype(declarations)
+
+        # construct the Particles object with the determined dtypes
+        return cls(nparticles, **bound_property_dtypes)
 
 
 class ParticlesView(_FrozenArrayMapping):
@@ -134,3 +182,60 @@ class ParticlesView(_FrozenArrayMapping):
 
     def __len__(self) -> int:
         return object.__getattribute__(self, "_length")
+
+
+_CONCRETE_NUMPY_TYPES_BY_PREFERENCE = (
+    # defaults that cover most use cases
+    np.float64,
+    np.float32,
+    np.complex128,
+    np.int32,
+    np.uint8,
+    np.dtype("datetime64[ns]"),
+    np.dtype("timedelta64[ns]"),
+    # rest of the float types
+    np.float16,
+    np.longdouble,
+    # rest of the complex types
+    np.complex64,
+    np.clongdouble,
+    # rest of the int types
+    np.int8,
+    np.int16,
+    np.int64,
+    # rest of the uint types
+    np.uint16,
+    np.uint32,
+    np.uint64,
+)
+
+
+def _find_valid_particle_property_dtype(declarations: list[ParticlePropertyDeclaration]) -> np.dtype:
+    """Find a valid dtype for a particle property given a set of declarations.
+
+    Parameters
+    ----------
+    declarations : Iterable[ParticlePropertyDeclaration]
+        The declarations to find a valid dtype for.
+
+    Returns
+    -------
+    np.dtype
+        A valid dtype that satisfies all declarations.
+
+    Raises
+    ------
+    ValueError
+        If no valid dtype can be found that satisfies all declarations.
+    """
+    for dtype in _CONCRETE_NUMPY_TYPES_BY_PREFERENCE:
+        try:
+            for declaration in declarations:
+                declaration.validate_dtype(dtype)
+            return np.dtype(dtype)
+        except TypeError:
+            continue
+
+    constraint_strings = [d._constraint_str for d in declarations]
+    constraint_message = "[ " + " ], [ ".join(constraint_strings) + " ]"
+    raise ValueError(f"No valid dtype found for particle property with constraints {constraint_message}.")

--- a/src/offline_particles/particles.py
+++ b/src/offline_particles/particles.py
@@ -91,9 +91,12 @@ class Particles(_FrozenArrayMapping):
     def __init__(self, nparticles: int, **bound_property_dtypes: np.dtype) -> None:
         """Initialize the Particles object.
 
-        Args:
-            nparticles: The number of particles.
-            **bound_property_dtypes: The bound property dtypes.
+        Parameters
+        ----------
+        nparticles : int
+            The number of particles.
+        **bound_property_dtypes : np.dtype
+            The bound property dtypes.
         """
         object.__setattr__(self, "_length", nparticles)
         arrays = {binding: np.zeros((nparticles,), dtype=dtype) for binding, dtype in bound_property_dtypes.items()}
@@ -155,8 +158,10 @@ class ParticlesView(_FrozenArrayMapping):
     def __init__(self, parent: Particles) -> None:
         """Initialize the ParticlesView.
 
-        Args:
-            parent: The parent Particles object.
+        Parameters
+        ----------
+        parent : Particles
+            The parent :class:`Particles` object.
         """
         arrays = {name: self.readonly_view(array) for name, array in parent.arrays.items()}
         object.__setattr__(self, "_length", len(parent))

--- a/src/offline_particles/simulation.py
+++ b/src/offline_particles/simulation.py
@@ -655,6 +655,8 @@ class Simulation:
         KeyError
             If the specified particle set does not exist in the simulation.
             Or if the kernel requires a particle property that is not available in the simulation.
+        TypeError
+            If a required particle property has an incompatible dtype. From :meth:`~ParticlePropertyDeclaration.validate_dtype`.
         """
         # get particles
         if particle_set not in self._particles:

--- a/src/offline_particles/simulation.py
+++ b/src/offline_particles/simulation.py
@@ -487,16 +487,16 @@ class Simulation:
     def step(self) -> None:
         """Advance the particle simulation by one timestep."""
         # run all pre step kernels
-        for name, particles in self._particles.items():
-            self._timesteppers[name].run_pre_step(particles, self._launcher, self._clock)
+        for pset_name, particles in self._particles.items():
+            self._timesteppers[pset_name].run_pre_step(particles, self._launcher, self._clock)
         # run main step
-        for name, particles in self._particles.items():
-            self._timesteppers[name].run_step(particles, self._launcher, self._clock)
+        for pset_name, particles in self._particles.items():
+            self._timesteppers[pset_name].run_step(particles, self._launcher, self._clock)
         # advance time
         self._clock.advance_time()
         # run all post step kernels
-        for name, particles in self._particles.items():
-            self._timesteppers[name].run_post_step(particles, self._launcher, self._clock)
+        for pset_name, particles in self._particles.items():
+            self._timesteppers[pset_name].run_post_step(particles, self._launcher, self._clock)
 
     def _invoke_events(self) -> None:
         """Invoke any scheduled events at the current time or iteration."""
@@ -508,8 +508,8 @@ class Simulation:
         )
         for event in events_to_be_invoked:
             # launch kernels
-            for name, particles in self._particles.items():
-                kernels = event.kernels.get(name, ())
+            for pset_name, particles in self._particles.items():
+                kernels = event.kernels.get(pset_name, ())
                 for kernel in kernels:
                     self._launcher.launch_kernel(kernel, particles, self.tinfo)
             # invoke event function
@@ -533,8 +533,8 @@ class Simulation:
             raise ValueError("No valid stopping condition set for simulation.")
 
         # run initialisation kernels
-        for name, particles in self._particles.items():
-            self._timesteppers[name].run_initialisation(particles, self._launcher, self._clock)
+        for pset_name, particles in self._particles.items():
+            self._timesteppers[pset_name].run_initialisation(particles, self._launcher, self._clock)
         # invoke events at initial time / iteration
         self._invoke_events()
 
@@ -580,11 +580,11 @@ class Simulation:
 
         Raises
         ------
-        ValueError
+        KeyError
             If the specified particle set does not exist in the simulation.
         """
         if particle_set not in self._particles:
-            raise ValueError(f"Particle set '{particle_set}' not found in simulation.")
+            raise KeyError(f"Particle set '{particle_set}' not found in simulation.")
         particles = self._particles[particle_set]
 
         # first make the inputs compatible with the particle arrays
@@ -629,23 +629,23 @@ class Simulation:
 
         Raises
         ------
-        ValueError
+        KeyError
             If the specified particle set does not exist in the simulation.
         """
         if particle_set not in self._particles:
-            raise ValueError(f"Particle set '{particle_set}' not found in simulation.")
+            raise KeyError(f"Particle set '{particle_set}' not found in simulation.")
 
         particle_property = self._particles[particle_set][property_name]
         values_array = np.asarray(values, dtype=particle_property.dtype)
         values_array = np.broadcast_to(values_array, particle_property.shape)
         particle_property[:] = values_array
 
-    def run_kernel(self, name: str, kernel: BoundKernel) -> None:
+    def run_kernel(self, particle_set: str, kernel: BoundKernel) -> None:
         """Execute a kernel on the particles.
 
         Parameters
         ----------
-        name : str
+        particle_set : str
             The name of the particle set to run the kernel on.
         kernel : BoundKernel
             The kernel to execute.
@@ -657,9 +657,9 @@ class Simulation:
             Or if the kernel requires a particle property that is not available in the simulation.
         """
         # get particles
-        if name not in self._particles:
-            raise KeyError(f"Particle set '{name}' not found in simulation.")
-        particles = self._particles[name]
+        if particle_set not in self._particles:
+            raise KeyError(f"Particle set '{particle_set}' not found in simulation.")
+        particles = self._particles[particle_set]
 
         # check required particle properties are available
         for bound_name, declaration in kernel.particle_property_declarations.items():

--- a/src/offline_particles/simulation.py
+++ b/src/offline_particles/simulation.py
@@ -19,7 +19,7 @@ from .events import (
     SimulationState,
 )
 from .fieldset import Fieldset
-from .kernels import BoundKernel, get_required_particle_property_dtypes
+from .kernels import BoundKernel
 from .launcher import Launcher, Tinfo
 from .output import AbstractOutputWriter, AbstractOutputWriterBuilder
 from .particles import Particles, ParticlesView
@@ -35,6 +35,7 @@ class ParticleSet:
     name: str
     nparticles: int
     timestepper: Timestepper
+    property_dtypes: dict[str, npt.DTypeLike] = dataclasses.field(default_factory=dict)
 
 
 class Simulation:
@@ -126,8 +127,7 @@ class Simulation:
             kernel_count += len(kernels)
 
             # then merge required particle properties from all kernels
-            particle_property_dtypes = get_required_particle_property_dtypes(*kernels)
-            self._particles[name] = Particles(nparticles, **particle_property_dtypes)
+            self._particles[name] = Particles.build_from_kernels(nparticles, pset.property_dtypes, kernels)
             self._particles_view[name] = ParticlesView(self._particles[name])
 
         # print a warning if kernel count is larger that history size
@@ -652,29 +652,22 @@ class Simulation:
 
         Raises
         ------
-        ValueError
+        KeyError
             If the specified particle set does not exist in the simulation.
             Or if the kernel requires a particle property that is not available in the simulation.
-        TypeError
-            If the kernel requires a particle property with a different dtype than what is available in the simulation
         """
         # get particles
         if name not in self._particles:
-            raise ValueError(f"Particle set '{name}' not found in simulation.")
+            raise KeyError(f"Particle set '{name}' not found in simulation.")
         particles = self._particles[name]
 
         # check required particle properties are available
-        required_property_dtypes = get_required_particle_property_dtypes(kernel)
-        for binding, dtype in required_property_dtypes.items():
-            if binding not in particles.arrays:
-                raise ValueError(
-                    f"Particle property '{binding}' required by kernel is not available in the simulation."
+        for bound_name, declaration in kernel.particle_property_declarations.items():
+            if bound_name not in particles.arrays:
+                raise KeyError(
+                    f"Particle property '{bound_name}' required by kernel is not available in the simulation."
                 )
-            if particles.arrays[binding].dtype != dtype:
-                raise TypeError(
-                    f"Particle property '{binding}' has dtype {particles.arrays[binding].dtype}, "
-                    f"but kernel declares dtype {dtype}."
-                )
+            declaration.validate_dtype(particles.arrays[bound_name].dtype)
         self._launcher.launch_kernel(kernel, particles, self.tinfo)
 
 

--- a/tests/kernels/test_fielddata_declaration.py
+++ b/tests/kernels/test_fielddata_declaration.py
@@ -1,0 +1,55 @@
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from offline_particles.fields import StaticField
+from offline_particles.kernels import FieldDataDeclaration
+
+
+def _make_field(dtype: npt.DTypeLike) -> StaticField:
+    arr = np.zeros((3,), dtype=dtype)
+    # 1D field with Z axis and centered stagger
+    return StaticField.from_arraylike(arr, axes=("Z",), staggers=("center",))
+
+
+def test_validate_field_dtype_mismatch_raises() -> None:
+    decl = FieldDataDeclaration("field", np.float32)
+    field = _make_field(np.int32)
+    with pytest.raises(TypeError):
+        decl.validate_field(field)
+
+
+def test_validate_field_accepts_exact_match_dtype() -> None:
+    decl = FieldDataDeclaration("field", np.float32)
+    field = _make_field(np.float32)
+    # should not raise
+    decl.validate_field(field)
+
+
+def test_validate_field_accepts_compatible_dtypes() -> None:
+    # Test that the validator accepts dtypes that are compatible with the declared dtype
+    # For example, float64 should be accepted when float32 is declared (since float64 is a superset of float32)
+    decl = FieldDataDeclaration("field", np.inexact)
+    field = _make_field(np.float64)
+    # should not raise
+    decl.validate_field(field)
+
+
+def test_validate_field_rejects_incompatible_dtypes() -> None:
+    # Test that the validator rejects dtypes that are not compatible with the declared dtype
+    # For example, int32 should not be accepted when inexact is declared
+    decl = FieldDataDeclaration("field", np.inexact)
+    field = _make_field(np.int32)
+    with pytest.raises(TypeError):
+        decl.validate_field(field)
+
+
+def test_validate_field_accepts_multiple_compatible_dtypes() -> None:
+    # Test that the validator accepts multiple dtypes that are compatible with the declared dtype
+    # For example, both float32 and float64 should be accepted when inexact is declared
+    decl = FieldDataDeclaration("field", (np.float32, np.float64))
+    field1 = _make_field(np.float32)
+    field2 = _make_field(np.float64)
+    # should not raise for either field
+    decl.validate_field(field1)
+    decl.validate_field(field2)

--- a/tests/kernels/test_interpolation_linear.py
+++ b/tests/kernels/test_interpolation_linear.py
@@ -61,21 +61,21 @@ class TestConstructLinearInterpolationKernel:
 
     def test_default_field_dtype_is_float64(self) -> None:
         kernel = construct_1D_interpolation_kernel("Z", "temperature", "temp_field")
-        assert kernel.kernel.field_data["field"].dtype == np.dtype(np.float64)
+        assert kernel.kernel.field_data["field"].dtype_constraints == (np.float64,)
 
     def test_custom_field_dtype_is_applied(self) -> None:
         kernel = construct_1D_interpolation_kernel("Z", "temperature", "temp_field", field_dtype=np.float32)
-        assert kernel.kernel.field_data["field"].dtype == np.dtype(np.float32)
+        assert kernel.kernel.field_data["field"].dtype_constraints == (np.float32,)
 
     def test_output_dtype_defaults_to_field_dtype(self) -> None:
         kernel = construct_1D_interpolation_kernel("Z", "temperature", "temp_field", field_dtype=np.float32)
-        assert kernel.kernel.particle_properties["output"].dtype == np.dtype(np.float32)
+        assert kernel.kernel.particle_properties["output"].dtype_constraints == (np.float32,)
 
     def test_custom_output_dtype_is_applied(self) -> None:
         kernel = construct_1D_interpolation_kernel(
             "Z", "temperature", "temp_field", field_dtype=np.float64, output_dtype=np.float32
         )
-        assert kernel.kernel.particle_properties["output"].dtype == np.dtype(np.float32)
+        assert kernel.kernel.particle_properties["output"].dtype_constraints == (np.float32,)
 
     def test_invalid_axis_string_raises(self) -> None:
         with pytest.raises(ValueError, match="not a valid ArrayAxis"):
@@ -146,21 +146,21 @@ class TestConstructBilinearInterpolationKernel:
 
     def test_default_field_dtype_is_float64(self) -> None:
         kernel = construct_2D_interpolation_kernel(("Z", "Y"), "temperature", "temp_field")
-        assert kernel.kernel.field_data["field"].dtype == np.dtype(np.float64)
+        assert kernel.kernel.field_data["field"].dtype_constraints == (np.float64,)
 
     def test_custom_field_dtype_is_applied(self) -> None:
         kernel = construct_2D_interpolation_kernel(("Z", "Y"), "temperature", "temp_field", field_dtype=np.float32)
-        assert kernel.kernel.field_data["field"].dtype == np.dtype(np.float32)
+        assert kernel.kernel.field_data["field"].dtype_constraints == (np.float32,)
 
     def test_output_dtype_defaults_to_field_dtype(self) -> None:
         kernel = construct_2D_interpolation_kernel(("Z", "Y"), "temperature", "temp_field", field_dtype=np.float32)
-        assert kernel.kernel.particle_properties["output"].dtype == np.dtype(np.float32)
+        assert kernel.kernel.particle_properties["output"].dtype_constraints == (np.float32,)
 
     def test_custom_output_dtype_is_applied(self) -> None:
         kernel = construct_2D_interpolation_kernel(
             ("Z", "Y"), "temperature", "temp_field", field_dtype=np.float64, output_dtype=np.float32
         )
-        assert kernel.kernel.particle_properties["output"].dtype == np.dtype(np.float32)
+        assert kernel.kernel.particle_properties["output"].dtype_constraints == (np.float32,)
 
     def test_wrong_number_of_axes_raises(self) -> None:
         with pytest.raises(ValueError, match="axes must be a tuple of two elements"):
@@ -239,21 +239,21 @@ class TestConstructTrilinearInterpolationKernel:
 
     def test_default_field_dtype_is_float64(self) -> None:
         kernel = construct_3D_interpolation_kernel(("Z", "Y", "X"), "temperature", "temp_field")
-        assert kernel.kernel.field_data["field"].dtype == np.dtype(np.float64)
+        assert kernel.kernel.field_data["field"].dtype_constraints == (np.float64,)
 
     def test_custom_field_dtype_is_applied(self) -> None:
         kernel = construct_3D_interpolation_kernel(("Z", "Y", "X"), "temperature", "temp_field", field_dtype=np.float32)
-        assert kernel.kernel.field_data["field"].dtype == np.dtype(np.float32)
+        assert kernel.kernel.field_data["field"].dtype_constraints == (np.float32,)
 
     def test_output_dtype_defaults_to_field_dtype(self) -> None:
         kernel = construct_3D_interpolation_kernel(("Z", "Y", "X"), "temperature", "temp_field", field_dtype=np.float32)
-        assert kernel.kernel.particle_properties["output"].dtype == np.dtype(np.float32)
+        assert kernel.kernel.particle_properties["output"].dtype_constraints == (np.float32,)
 
     def test_custom_output_dtype_is_applied(self) -> None:
         kernel = construct_3D_interpolation_kernel(
             ("Z", "Y", "X"), "temperature", "temp_field", field_dtype=np.float64, output_dtype=np.float32
         )
-        assert kernel.kernel.particle_properties["output"].dtype == np.dtype(np.float32)
+        assert kernel.kernel.particle_properties["output"].dtype_constraints == (np.float32,)
 
     def test_wrong_number_of_axes_raises(self) -> None:
         with pytest.raises(ValueError, match="axes must be a tuple of three elements"):

--- a/tests/kernels/test_kernel_input_declaration.py
+++ b/tests/kernels/test_kernel_input_declaration.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+
+from offline_particles.kernels._kernels import KernelInputDeclaration
+
+
+class TestKernelInputDeclarationConstruction:
+    def test_single_dtype_constraint_is_stored_as_tuple(self) -> None:
+        declaration = KernelInputDeclaration("x", np.float32)
+
+        assert declaration.dtype_constraints == (np.float32,)
+
+    def test_iterable_dtype_constraints_are_stored_as_tuple(self) -> None:
+        declaration = KernelInputDeclaration("x", [np.float32, np.float64])
+
+        assert declaration.dtype_constraints == (np.float32, np.float64)
+
+    def test_invalid_dtype_constraint_type_raises(self) -> None:
+        with pytest.raises(TypeError, match="subtype of np.generic"):
+            KernelInputDeclaration("x", int)  # type: ignore[invalid-argument-type]
+
+    def test_invalid_dtype_constraint_object_raises(self) -> None:
+        with pytest.raises(TypeError, match="subtype of np.generic"):
+            KernelInputDeclaration("x", (np.float32, np.dtype(np.float64)))  # type: ignore[invalid-argument-type]
+
+
+class TestKernelInputDeclarationValidateDtype:
+    def test_accepts_exact_dtype_type(self) -> None:
+        declaration = KernelInputDeclaration("x", np.float32)
+
+        declaration.validate_dtype(np.float32)
+
+    def test_accepts_numpy_dtype_object(self) -> None:
+        declaration = KernelInputDeclaration("x", np.float32)
+
+        declaration.validate_dtype(np.dtype(np.float32))
+
+    def test_accepts_abstract_dtype_constraint(self) -> None:
+        declaration = KernelInputDeclaration("x", np.floating)
+
+        declaration.validate_dtype(np.float32)
+
+    def test_accepts_multiple_dtype_constraints(self) -> None:
+        declaration = KernelInputDeclaration("x", (np.float32, np.int32))
+
+        declaration.validate_dtype(np.int32)
+
+    def test_accepts_exact_and_abstract_dtype_constraints(self) -> None:
+        declaration = KernelInputDeclaration("x", (np.float32, np.integer))
+
+        declaration.validate_dtype(np.float32)
+        declaration.validate_dtype(np.int32)
+
+    def test_rejects_incompatible_dtype(self) -> None:
+        declaration = KernelInputDeclaration("x", np.float32)
+
+        with pytest.raises(TypeError, match="dtype constraints"):
+            declaration.validate_dtype(np.int32)

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -1,4 +1,4 @@
-"""Tests for ParticleKernel, BoundKernel, and get_required_particle_property_dtypes."""
+"""Tests for ParticleKernel and BoundKernel."""
 
 import numpy as np
 import pytest
@@ -9,7 +9,6 @@ from offline_particles.kernels import (
     ParticleKernel,
     ParticlePropertyDeclaration,
     ScalarDeclaration,
-    get_required_particle_property_dtypes,
 )
 
 # ---------------------------------------------------------------------------
@@ -51,7 +50,7 @@ class TestParticleKernelConstruction:
         decl = ParticlePropertyDeclaration("x", np.float64)
         kernel = ParticleKernel(_noop, [decl])
         assert "x" in kernel.particle_properties
-        assert kernel.particle_properties["x"].dtype == np.dtype(np.float64)
+        assert kernel.particle_properties["x"].dtype_constraints == (np.float64,)
 
     def test_scalars_stored(self) -> None:
         decl = ScalarDeclaration("_dt", np.float64)
@@ -243,51 +242,3 @@ class TestBoundKernelChaining:
         assert "x" in chained.particle_property_bindings
         assert "y" in chained.particle_property_bindings
 
-
-# ---------------------------------------------------------------------------
-# get_required_particle_property_dtypes
-# ---------------------------------------------------------------------------
-
-
-class TestGetRequiredParticlePropertyDtypes:
-    def test_single_kernel(self) -> None:
-        kernel = ParticleKernel(_noop, [ParticlePropertyDeclaration("x", np.float64)])
-        bound = BoundKernel(kernel)
-        dtypes = get_required_particle_property_dtypes(bound)
-        assert dtypes["x"] == np.dtype(np.float64)
-
-    def test_multiple_kernels_no_overlap(self) -> None:
-        k1 = ParticleKernel(_noop, [ParticlePropertyDeclaration("x", np.float64)])
-        k2 = ParticleKernel(_noop2, [ParticlePropertyDeclaration("y", np.float32)])
-        b1 = BoundKernel(k1)
-        b2 = BoundKernel(k2)
-        dtypes = get_required_particle_property_dtypes(b1, b2)
-        assert dtypes["x"] == np.dtype(np.float64)
-        assert dtypes["y"] == np.dtype(np.float32)
-
-    def test_conflicting_dtypes_raises(self) -> None:
-        k1 = ParticleKernel(_noop, [ParticlePropertyDeclaration("x", np.float64)])
-        k2 = ParticleKernel(_noop2, [ParticlePropertyDeclaration("x", np.int32)])
-        b1 = BoundKernel(k1)
-        b2 = BoundKernel(k2)
-        with pytest.raises(ValueError, match="Conflicting"):
-            get_required_particle_property_dtypes(b1, b2)
-
-    def test_same_dtype_no_conflict(self) -> None:
-        k1 = ParticleKernel(_noop, [ParticlePropertyDeclaration("x", np.float64)])
-        k2 = ParticleKernel(_noop2, [ParticlePropertyDeclaration("x", np.float64)])
-        b1 = BoundKernel(k1)
-        b2 = BoundKernel(k2)
-        dtypes = get_required_particle_property_dtypes(b1, b2)
-        assert dtypes["x"] == np.dtype(np.float64)
-
-    def test_uses_binding_name_not_declared_name(self) -> None:
-        kernel = ParticleKernel(_noop, [ParticlePropertyDeclaration("x", np.float64)])
-        bound = BoundKernel(kernel, particle_property_bindings={"x": "xidx"})
-        dtypes = get_required_particle_property_dtypes(bound)
-        assert "xidx" in dtypes
-        assert "x" not in dtypes
-
-    def test_empty_returns_empty(self) -> None:
-        dtypes = get_required_particle_property_dtypes()
-        assert dict(dtypes) == {}

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -241,4 +241,3 @@ class TestBoundKernelChaining:
         chained = b1.chain_with(b2)
         assert "x" in chained.particle_property_bindings
         assert "y" in chained.particle_property_bindings
-

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -241,3 +241,26 @@ class TestBoundKernelChaining:
         chained = b1.chain_with(b2)
         assert "x" in chained.particle_property_bindings
         assert "y" in chained.particle_property_bindings
+
+
+class TestBoundKernelValidation:
+    def test_validate_particles_missing_property_raises(self) -> None:
+        kernel = ParticleKernel(_noop, [ParticlePropertyDeclaration("x", np.float32)])
+        bound = BoundKernel(kernel)
+        particles = {"y": np.zeros(3, dtype=np.float32)}
+        with pytest.raises(KeyError):
+            bound.validate_particles(particles)
+
+    def test_validate_particles_invalid_dtype_raises(self) -> None:
+        kernel = ParticleKernel(_noop, [ParticlePropertyDeclaration("x", np.float32)])
+        bound = BoundKernel(kernel)
+        particles = {"x": np.zeros(3, dtype=np.int32)}
+        with pytest.raises(TypeError):
+            bound.validate_particles(particles)
+
+    def test_validate_particles_accepts_valid_dtype(self) -> None:
+        kernel = ParticleKernel(_noop, [ParticlePropertyDeclaration("x", np.float32)])
+        bound = BoundKernel(kernel)
+        particles = {"x": np.zeros(3, dtype=np.float32)}
+        # should not raise
+        bound.validate_particles(particles)

--- a/tests/kernels/test_layout_validators.py
+++ b/tests/kernels/test_layout_validators.py
@@ -191,7 +191,7 @@ class TestLayoutValidatorsWithFieldDataDeclaration:
         data = np.ones((5, 6), dtype=np.float64)
         field = StaticField.from_numpy(data, ("Y", "X"), ("center", "center"))
         decl = FieldDataDeclaration("u", np.float64, [validate_ZYX_ordering])
-        with pytest.raises(ValueError, match="Expected axes"):
+        with pytest.raises(ValueError, match="layout constraints"):
             decl.validate_field(field)
 
     def test_validate_field_passes_with_no_validators(self) -> None:
@@ -227,7 +227,7 @@ class TestLayoutValidatorsWithFieldDataDeclaration:
         data = np.ones((5, 6), dtype=np.float64)
         field = StaticField.from_numpy(data, ("Y", "X"), ("center", "center"))
         decl = FieldDataDeclaration("u", np.float64, [validate_YX_ordering, validate_ZYX_ordering])
-        with pytest.raises(ValueError, match="Expected axes"):
+        with pytest.raises(ValueError, match="layout constraints"):
             decl.validate_field(field)
 
 

--- a/tests/output/test_interpolation.py
+++ b/tests/output/test_interpolation.py
@@ -79,12 +79,12 @@ class TestInterpolateFields:
     def test_custom_particle_property_prefix(self) -> None:
         fs = _make_fieldset()
         outputs = interpolate_fields(fs, ["u"], particle_property_prefix="_custom")
-        assert outputs["u"].particle_property.name.startswith("_custom")
+        assert outputs["u"].particle_property.startswith("_custom")
 
     def test_default_particle_property_prefix(self) -> None:
         fs = _make_fieldset()
         outputs = interpolate_fields(fs, ["u"])
-        assert outputs["u"].particle_property.name.startswith("_output")
+        assert outputs["u"].particle_property.startswith("_output")
 
     def test_variables_can_be_supplied_as_any_iterable(self) -> None:
         fs = _make_fieldset()

--- a/tests/output/test_output.py
+++ b/tests/output/test_output.py
@@ -9,15 +9,15 @@ from offline_particles.output import Output
 class TestOutputConstruction:
     def test_default_dtype_is_float64(self) -> None:
         output = Output("xidx")
-        assert output.particle_property.dtype == np.dtype(np.float64)
+        assert output.dtype == np.dtype(np.float64)
 
     def test_explicit_dtype(self) -> None:
         output = Output("xidx", dtype=np.float32)
-        assert output.particle_property.dtype == np.dtype(np.float32)
+        assert output.dtype == np.dtype(np.float32)
 
     def test_particle_property_name(self) -> None:
         output = Output("my_property")
-        assert output.particle_property.name == "my_property"
+        assert output.particle_property == "my_property"
 
     def test_no_kernels_by_default(self) -> None:
         output = Output("xidx")
@@ -35,17 +35,3 @@ class TestOutputConstruction:
         output = Output("xidx")
         with pytest.raises(AttributeError):
             output.particle_property = output.particle_property  # type: ignore[misc]
-
-
-class TestOutputRequiredPropertyDtypes:
-    def test_includes_particle_property(self) -> None:
-        output = Output("xidx", dtype=np.float32)
-        required = output.required_property_dtypes
-        assert "xidx" in required
-        assert required["xidx"] == np.dtype(np.float32)
-
-    def test_is_read_only_mapping(self) -> None:
-        output = Output("xidx")
-        required = output.required_property_dtypes
-        with pytest.raises(TypeError):
-            required["new_key"] = np.dtype(np.float64)  # type: ignore[index]

--- a/tests/particles/test_particles_build.py
+++ b/tests/particles/test_particles_build.py
@@ -2,23 +2,75 @@ import numpy as np
 import pytest
 
 from offline_particles.kernels import BoundKernel, ParticleKernel, ParticlePropertyDeclaration
-from offline_particles.particles import Particles
+from offline_particles.particles import Particles, _find_valid_particle_property_dtype
 
 
-def _make_bound_kernel_for_x(dtype):
-    k = ParticleKernel(lambda pp, sc, fd: None, [ParticlePropertyDeclaration("x", dtype)])
-    return BoundKernel(k)
+def _make_bound_kernel(
+    declared_name: str,
+    dtype_constraint: type[np.generic],
+    *,
+    bound_name: str | None = None,
+) -> BoundKernel:
+    kernel = ParticleKernel(lambda pp, sc, fd: None, [ParticlePropertyDeclaration(declared_name, dtype_constraint)])
+    if bound_name is None:
+        return BoundKernel(kernel)
+    return BoundKernel(kernel, particle_property_bindings={declared_name: bound_name})
+
+
+def test_find_valid_particle_property_dtype_prefers_float64_for_floating_constraint() -> None:
+    declarations = [ParticlePropertyDeclaration("x", np.floating)]
+
+    dtype = _find_valid_particle_property_dtype(declarations)
+
+    assert dtype == np.dtype(np.float64)
+
+
+def test_find_valid_particle_property_dtype_respects_intersection_of_constraints() -> None:
+    declarations = [
+        ParticlePropertyDeclaration("x", np.floating),
+        ParticlePropertyDeclaration("x", np.float32),
+    ]
+
+    dtype = _find_valid_particle_property_dtype(declarations)
+
+    assert dtype == np.dtype(np.float32)
+
+
+def test_find_valid_particle_property_dtype_raises_when_unsatisfiable() -> None:
+    declarations = [
+        ParticlePropertyDeclaration("x", np.float32),
+        ParticlePropertyDeclaration("x", np.int32),
+    ]
+
+    with pytest.raises(ValueError, match="No valid dtype found"):
+        _find_valid_particle_property_dtype(declarations)
+
+
+def test_find_valid_particle_property_dtype_supports_datetime64_constraints() -> None:
+    declarations = [ParticlePropertyDeclaration("x", np.datetime64)]
+
+    dtype = _find_valid_particle_property_dtype(declarations)
+
+    assert dtype == np.dtype("datetime64[ns]")
+
+
+def test_find_valid_particle_property_dtype_supports_timedelta64_constraints() -> None:
+    declarations = [ParticlePropertyDeclaration("x", np.timedelta64)]
+
+    dtype = _find_valid_particle_property_dtype(declarations)
+
+    assert dtype == np.dtype("timedelta64[ns]")
 
 
 def test_build_from_kernels_conflicting_constraints_raises() -> None:
-    b1 = _make_bound_kernel_for_x(np.float32)
-    b2 = _make_bound_kernel_for_x(np.int32)
+    b1 = _make_bound_kernel("x", np.float32)
+    b2 = _make_bound_kernel("x", np.int32)
     with pytest.raises(ValueError):
         Particles.build_from_kernels(3, {}, [b1, b2])
 
 
 def test_build_from_kernels_uses_specified_dtype_and_validates() -> None:
-    b = _make_bound_kernel_for_x(np.float32)
+    b = _make_bound_kernel("x", np.float32)
     # valid specified dtype
     p = Particles.build_from_kernels(2, {"x": np.float32}, [b])
     assert p.dtypes["x"] == np.dtype(np.float32)
@@ -26,3 +78,51 @@ def test_build_from_kernels_uses_specified_dtype_and_validates() -> None:
     # invalid specified dtype should raise
     with pytest.raises(TypeError):
         Particles.build_from_kernels(2, {"x": np.int32}, [b])
+
+
+def test_build_from_kernels_merges_constraints_by_bound_name() -> None:
+    # Different declarations can bind to the same name; constraints should be intersected.
+    b1 = _make_bound_kernel("x", np.floating, bound_name="shared")
+    b2 = _make_bound_kernel("temperature", np.float32, bound_name="shared")
+
+    particles = Particles.build_from_kernels(4, {}, [b1, b2])
+
+    assert particles.dtypes["shared"] == np.dtype(np.float32)
+
+
+def test_build_from_kernels_accepts_dtype_like_string_from_user() -> None:
+    b = _make_bound_kernel("x", np.floating)
+
+    particles = Particles.build_from_kernels(2, {"x": "float16"}, [b])
+
+    assert particles.dtypes["x"] == np.dtype(np.float16)
+
+
+def test_build_from_kernels_invalid_dtype_like_string_raises() -> None:
+    b = _make_bound_kernel("x", np.floating)
+
+    with pytest.raises(TypeError):
+        Particles.build_from_kernels(2, {"x": "not-a-dtype"}, [b])
+
+
+def test_build_from_kernels_specified_dtype_must_satisfy_all_constraints() -> None:
+    b1 = _make_bound_kernel("x", np.floating)
+    b2 = _make_bound_kernel("x", np.float32)
+
+    with pytest.raises(TypeError):
+        Particles.build_from_kernels(2, {"x": np.float64}, [b1, b2])
+
+
+def test_build_from_kernels_accepts_user_specified_datetime64_dtype() -> None:
+    b = _make_bound_kernel("x", np.datetime64)
+
+    particles = Particles.build_from_kernels(2, {"x": np.dtype("datetime64[ms]")}, [b])
+
+    assert particles.dtypes["x"] == np.dtype("datetime64[ms]")
+
+
+def test_build_from_kernels_rejects_datetime64_for_timedelta64_constraint() -> None:
+    b = _make_bound_kernel("x", np.timedelta64)
+
+    with pytest.raises(TypeError):
+        Particles.build_from_kernels(2, {"x": np.dtype("datetime64[ns]")}, [b])

--- a/tests/particles/test_particles_build.py
+++ b/tests/particles/test_particles_build.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+
+from offline_particles.kernels import BoundKernel, ParticleKernel, ParticlePropertyDeclaration
+from offline_particles.particles import Particles
+
+
+def _make_bound_kernel_for_x(dtype):
+    k = ParticleKernel(lambda pp, sc, fd: None, [ParticlePropertyDeclaration("x", dtype)])
+    return BoundKernel(k)
+
+
+def test_build_from_kernels_conflicting_constraints_raises() -> None:
+    b1 = _make_bound_kernel_for_x(np.float32)
+    b2 = _make_bound_kernel_for_x(np.int32)
+    with pytest.raises(ValueError):
+        Particles.build_from_kernels(3, {}, [b1, b2])
+
+
+def test_build_from_kernels_uses_specified_dtype_and_validates() -> None:
+    b = _make_bound_kernel_for_x(np.float32)
+    # valid specified dtype
+    p = Particles.build_from_kernels(2, {"x": np.float32}, [b])
+    assert p.dtypes["x"] == np.dtype(np.float32)
+
+    # invalid specified dtype should raise
+    with pytest.raises(TypeError):
+        Particles.build_from_kernels(2, {"x": np.int32}, [b])


### PR DESCRIPTION
Given we are switching to numba based kernels, as opposed to Cython based kernels, we can be much more flexible in the types these kernels accept. Therefore, rather than specifying an exact type we specify type constraints using `np.issubtype`. This necessitates a refactor of particle property validation, particle construction and the kernel factories. 