### PR TITLE
86 need to ensure zidx yidx and xidx are always included as particle properties even if simulations are 1 or 2d

### DIFF
--- a/src/offline_particles/particles.py
+++ b/src/offline_particles/particles.py
@@ -39,7 +39,7 @@ class _FrozenArrayMapping:
             raise ValueError("All arrays must have the same shape. Got shapes: " + ", ".join(str(s) for s in shapes))
         object.__setattr__(self, "_shape", shapes.pop())
         object.__setattr__(self, "_dtypes", types.MappingProxyType({name: arr.dtype for name, arr in arrays.items()}))
-        object.__setattr__(self, "_arrays", types.MappingProxyType(arrays))
+        object.__setattr__(self, "_arrays", types.MappingProxyType(dict(arrays)))
 
     def __setattr__(self, name, value):
         raise AttributeError(f"{self.__class__.__name__} is immutable")

--- a/src/offline_particles/particles.py
+++ b/src/offline_particles/particles.py
@@ -103,7 +103,12 @@ class Particles(_FrozenArrayMapping):
         nparticles : int
             The number of particles.
         bound_property_dtypes : Mapping[str, np.dtype]
-            The bound property dtypes.
+            Dtypes for additional particle properties to create. The required
+            particle properties ``status``, ``zidx``, ``yidx``, and ``xidx``
+            are always created with their required dtypes, even if they are
+            not included in this mapping. If this mapping includes any of
+            those required property names, the provided dtypes are only used
+            for validation and must exactly match the required dtypes.
 
         Raises
         ------

--- a/src/offline_particles/particles.py
+++ b/src/offline_particles/particles.py
@@ -8,7 +8,12 @@ import numpy.typing as npt
 
 from .kernels import BoundKernel, ParticlePropertyDeclaration
 
-REQUIRED_PARTICLE_PROPERTY_FIELDS = {"status": np.uint8, "zidx": np.float64, "yidx": np.float64, "xidx": np.float64}
+_REQUIRED_PARTICLE_PROPERTY_FIELDS = {
+    "status": np.dtype(np.uint8),
+    "zidx": np.dtype(np.float64),
+    "yidx": np.dtype(np.float64),
+    "xidx": np.dtype(np.float64),
+}
 
 
 class _FrozenArrayMapping:
@@ -99,9 +104,37 @@ class Particles(_FrozenArrayMapping):
             The number of particles.
         bound_property_dtypes : Mapping[str, np.dtype]
             The bound property dtypes.
+
+        Raises
+        ------
+        ValueError
+            If a passed dtype is incompatible with the required dtypes.
         """
         object.__setattr__(self, "_length", nparticles)
-        arrays = {binding: np.zeros((nparticles,), dtype=dtype) for binding, dtype in bound_property_dtypes.items()}
+
+        # sort the additional bindings alphabetically, but with private fields (those starting with "_") coming after public ones
+        bindings = sorted(bound_property_dtypes.keys(), key=lambda binding: (binding.startswith("_"), binding))
+        bindings_dtypes = {binding: np.dtype(bound_property_dtypes[binding]) for binding in bindings}
+
+        # remove any required fields from the additional bindings, since we already created arrays for those and checked their dtypes
+        for required_binding, dtype in _REQUIRED_PARTICLE_PROPERTY_FIELDS.items():
+            provided_dtype = bindings_dtypes.pop(required_binding, None)
+            if provided_dtype is None:
+                continue
+            if provided_dtype != dtype:
+                raise ValueError(
+                    f"Invalid dtype for required particle property '{required_binding}'. Provided dtype {provided_dtype} is not equal to required dtype {dtype}."
+                )
+
+        # build up arrays starting with the required fields
+        arrays = {
+            binding: np.zeros((nparticles,), dtype=dtype)
+            for binding, dtype in _REQUIRED_PARTICLE_PROPERTY_FIELDS.items()
+        }
+
+        # now add the additional fields, checking that they are compatible with any arrays we already created for the required fields
+        for binding, dtype in bindings_dtypes.items():
+            arrays[binding] = np.zeros((nparticles,), dtype=dtype)
 
         super().__init__(arrays=arrays)
 

--- a/src/offline_particles/particles.py
+++ b/src/offline_particles/particles.py
@@ -8,18 +8,20 @@ import numpy.typing as npt
 
 from .kernels import BoundKernel, ParticlePropertyDeclaration
 
+REQUIRED_PARTICLE_PROPERTY_FIELDS = {"status": np.uint8, "zidx": np.float64, "yidx": np.float64, "xidx": np.float64}
+
 
 class _FrozenArrayMapping:
     """A mapping-like object that holds equi-shaped arrays and prevents modification."""
 
     __slots__ = ("_arrays", "_dtypes", "_shape")
 
-    def __init__(self, **arrays: npt.NDArray) -> None:
+    def __init__(self, arrays: Mapping[str, npt.NDArray]) -> None:
         """Initialize the mapping with given arrays.
 
         Parameters
         ----------
-        **arrays : npt.NDArray
+        arrays : Mapping[str, npt.NDArray]
             The arrays to store in the mapping.
 
         Raises
@@ -88,20 +90,20 @@ class _FrozenArrayMapping:
 class Particles(_FrozenArrayMapping):
     __slots__ = ("_length",)
 
-    def __init__(self, nparticles: int, **bound_property_dtypes: np.dtype) -> None:
+    def __init__(self, nparticles: int, bound_property_dtypes: Mapping[str, np.dtype]) -> None:
         """Initialize the Particles object.
 
         Parameters
         ----------
         nparticles : int
             The number of particles.
-        **bound_property_dtypes : np.dtype
+        bound_property_dtypes : Mapping[str, np.dtype]
             The bound property dtypes.
         """
         object.__setattr__(self, "_length", nparticles)
         arrays = {binding: np.zeros((nparticles,), dtype=dtype) for binding, dtype in bound_property_dtypes.items()}
 
-        super().__init__(**arrays)
+        super().__init__(arrays=arrays)
 
     def __len__(self) -> int:
         return object.__getattribute__(self, "_length")
@@ -147,7 +149,7 @@ class Particles(_FrozenArrayMapping):
                 bound_property_dtypes[name] = _find_valid_particle_property_dtype(declarations)
 
         # construct the Particles object with the determined dtypes
-        return cls(nparticles, **bound_property_dtypes)
+        return cls(nparticles, bound_property_dtypes=bound_property_dtypes)
 
 
 class ParticlesView(_FrozenArrayMapping):
@@ -165,7 +167,7 @@ class ParticlesView(_FrozenArrayMapping):
         """
         arrays = {name: self.readonly_view(array) for name, array in parent.arrays.items()}
         object.__setattr__(self, "_length", len(parent))
-        super().__init__(**arrays)
+        super().__init__(arrays=arrays)
 
     @staticmethod
     def readonly_view(array: npt.NDArray) -> npt.NDArray:

--- a/src/offline_particles/particles.py
+++ b/src/offline_particles/particles.py
@@ -128,7 +128,9 @@ class Particles(_FrozenArrayMapping):
                 continue
             if provided_dtype != dtype:
                 raise ValueError(
-                    f"Invalid dtype for required particle property '{required_binding}'. Provided dtype {provided_dtype} is not equal to required dtype {dtype}."
+                    f"Invalid dtype for required particle property "
+                    f"'{required_binding}'. Provided dtype {provided_dtype} "
+                    f"is not equal to required dtype {dtype}."
                 )
 
         # build up arrays starting with the required fields

--- a/tests/events/test_events.py
+++ b/tests/events/test_events.py
@@ -12,7 +12,7 @@ from offline_particles.particles import Particles, ParticlesView
 
 
 def _make_state(time: float = 0.0, iteration: int = 0) -> SimulationState:
-    particles = Particles(3, x=np.dtype(np.float64))
+    particles = Particles(3, {"x": np.dtype(np.float64)})
     view = ParticlesView(particles)
     return SimulationState(
         time=np.float64(time),

--- a/tests/kernels/test_kernel_input_declaration.py
+++ b/tests/kernels/test_kernel_input_declaration.py
@@ -2,6 +2,13 @@ import numpy as np
 import pytest
 
 from offline_particles.kernels._kernels import KernelInputDeclaration
+from offline_particles.kernels.input_declarations import (
+    STATUS_DECLARATION,
+    XIDX_DECLARATION,
+    YIDX_DECLARATION,
+    ZIDX_DECLARATION,
+)
+from offline_particles.particles import _REQUIRED_PARTICLE_PROPERTY_FIELDS
 
 
 class TestKernelInputDeclarationConstruction:
@@ -56,3 +63,29 @@ class TestKernelInputDeclarationValidateDtype:
 
         with pytest.raises(TypeError, match="dtype constraints"):
             declaration.validate_dtype(np.int32)
+
+
+class TestRequiredParticlePropertyDeclarations:
+    @pytest.mark.parametrize(
+        ("declaration", "expected_name", "expected_dtype"),
+        [
+            (STATUS_DECLARATION, "status", np.dtype(np.uint8)),
+            (ZIDX_DECLARATION, "zidx", np.dtype(np.float64)),
+            (YIDX_DECLARATION, "yidx", np.dtype(np.float64)),
+            (XIDX_DECLARATION, "xidx", np.dtype(np.float64)),
+        ],
+    )
+    def test_required_particle_property_declarations_match_particles_module(
+        self,
+        declaration: KernelInputDeclaration,
+        expected_name: str,
+        expected_dtype: np.dtype,
+    ) -> None:
+        assert declaration.name == expected_name
+        assert declaration.dtype_constraints == (expected_dtype.type,)
+        assert _REQUIRED_PARTICLE_PROPERTY_FIELDS[expected_name] == expected_dtype
+
+    def test_required_particle_property_names_match_particles_module(self) -> None:
+        assert {STATUS_DECLARATION.name, ZIDX_DECLARATION.name, YIDX_DECLARATION.name, XIDX_DECLARATION.name} == set(
+            _REQUIRED_PARTICLE_PROPERTY_FIELDS
+        )

--- a/tests/kernels/test_kernel_input_declaration.py
+++ b/tests/kernels/test_kernel_input_declaration.py
@@ -86,6 +86,9 @@ class TestRequiredParticlePropertyDeclarations:
         assert _REQUIRED_PARTICLE_PROPERTY_FIELDS[expected_name] == expected_dtype
 
     def test_required_particle_property_names_match_particles_module(self) -> None:
-        assert {STATUS_DECLARATION.name, ZIDX_DECLARATION.name, YIDX_DECLARATION.name, XIDX_DECLARATION.name} == set(
-            _REQUIRED_PARTICLE_PROPERTY_FIELDS
-        )
+        assert {
+            STATUS_DECLARATION.name,
+            ZIDX_DECLARATION.name,
+            YIDX_DECLARATION.name,
+            XIDX_DECLARATION.name,
+        } == set(_REQUIRED_PARTICLE_PROPERTY_FIELDS)

--- a/tests/output/test_static_output.py
+++ b/tests/output/test_static_output.py
@@ -35,7 +35,7 @@ def _make_state(nparticles: int = 5, property_values: dict | None = None) -> Sim
         for name, values in property_values.items():
             kwargs[name] = np.asarray(values).dtype
 
-    particles = Particles(nparticles, **kwargs)
+    particles = Particles(nparticles, kwargs)
 
     if property_values:
         for name, values in property_values.items():

--- a/tests/output/test_time_dependent_output.py
+++ b/tests/output/test_time_dependent_output.py
@@ -43,7 +43,7 @@ def _make_state(
         for name, values in property_values.items():
             kwargs[name] = np.asarray(values).dtype
 
-    p = Particles(nparticles, **kwargs)
+    p = Particles(nparticles, kwargs)
 
     if property_values:
         for name, values in property_values.items():
@@ -86,11 +86,11 @@ def _make_multi_set_state(
     SimulationState
         A SimulationState containing two particle sets.
     """
-    p1 = Particles(nparticles_ps1, xidx=np.dtype(np.float64))
+    p1 = Particles(nparticles_ps1, {"xidx": np.dtype(np.float64)})
     if values_ps1 is not None:
         p1["xidx"][:] = np.asarray(values_ps1, dtype=np.float64)
 
-    p2 = Particles(nparticles_ps2, xidx=np.dtype(np.float64))
+    p2 = Particles(nparticles_ps2, {"xidx": np.dtype(np.float64)})
     if values_ps2 is not None:
         p2["xidx"][:] = np.asarray(values_ps2, dtype=np.float64)
 

--- a/tests/particles/test_particles.py
+++ b/tests/particles/test_particles.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from offline_particles.particles import Particles, ParticlesView
+from offline_particles.particles import Particles, ParticlesView, _FrozenArrayMapping
 
 # ---------------------------------------------------------------------------
 # _FrozenArrayMapping (tested indirectly through Particles)
@@ -12,7 +12,7 @@ from offline_particles.particles import Particles, ParticlesView
 
 class TestFrozenArrayMappingShapeCheck:
     def test_accepts_arrays_with_same_shape(self) -> None:
-        p = Particles(5, x=np.dtype(np.float64), y=np.dtype(np.float64))
+        p = Particles(5, {"x": np.dtype(np.float64), "y": np.dtype(np.float64)})
         assert p.shape == (5,)
 
     def test_rejects_arrays_with_different_shapes(self) -> None:
@@ -20,63 +20,61 @@ class TestFrozenArrayMappingShapeCheck:
         # via direct construction with inconsistent arrays through the inherited path.
         # Easiest: subclass or use the fact that Particles itself enforces uniform shape.
         # The shape mismatch path is exercised when constructing via **arrays that differ.
-        from offline_particles.particles import _FrozenArrayMapping
-
         a = np.zeros((3,))
         b = np.zeros((4,))
         with pytest.raises(ValueError, match="same shape"):
-            _FrozenArrayMapping(a=a, b=b)
+            _FrozenArrayMapping({"a": a, "b": b})
 
     def test_shape_property(self) -> None:
-        p = Particles(7, x=np.dtype(np.float64))
+        p = Particles(7, {"x": np.dtype(np.float64)})
         assert p.shape == (7,)
 
     def test_dtypes_property(self) -> None:
-        p = Particles(3, x=np.dtype(np.float64), y=np.dtype(np.int32))
+        p = Particles(3, {"x": np.dtype(np.float64), "y": np.dtype(np.int32)})
         assert p.dtypes["x"] == np.dtype(np.float64)
         assert p.dtypes["y"] == np.dtype(np.int32)
 
     def test_arrays_property(self) -> None:
-        p = Particles(4, val=np.dtype(np.float32))
+        p = Particles(4, {"val": np.dtype(np.float32)})
         assert "val" in p.arrays
         assert p.arrays["val"].dtype == np.dtype(np.float32)
 
     def test_getattr_returns_array(self) -> None:
-        p = Particles(5, x=np.dtype(np.float64))
+        p = Particles(5, {"x": np.dtype(np.float64)})
         assert isinstance(p.x, np.ndarray)
 
     def test_getattr_missing_raises(self) -> None:
-        p = Particles(5, x=np.dtype(np.float64))
+        p = Particles(5, {"x": np.dtype(np.float64)})
         with pytest.raises(AttributeError):
             _ = p.nonexistent
 
     def test_getitem_returns_array(self) -> None:
-        p = Particles(5, x=np.dtype(np.float64))
+        p = Particles(5, {"x": np.dtype(np.float64)})
         assert isinstance(p["x"], np.ndarray)
 
     def test_getitem_missing_raises(self) -> None:
-        p = Particles(5, x=np.dtype(np.float64))
+        p = Particles(5, {"x": np.dtype(np.float64)})
         with pytest.raises(KeyError):
             _ = p["nonexistent"]
 
     def test_setattr_raises(self) -> None:
-        p = Particles(5, x=np.dtype(np.float64))
+        p = Particles(5, {"x": np.dtype(np.float64)})
         with pytest.raises(AttributeError):
             p.x = np.zeros(5)  # type: ignore[misc]
 
     def test_repr(self) -> None:
-        p = Particles(3, x=np.dtype(np.float64))
+        p = Particles(3, {"x": np.dtype(np.float64)})
         r = repr(p)
         assert "shape" in r
         assert "float64" in r
 
     def test_str_with_no_hidden_fields(self) -> None:
-        p = Particles(3, x=np.dtype(np.float64))
+        p = Particles(3, {"x": np.dtype(np.float64)})
         s = str(p)
         assert "x" in s
 
     def test_str_with_hidden_fields(self) -> None:
-        p = Particles(3, x=np.dtype(np.float64), _hidden=np.dtype(np.float64))
+        p = Particles(3, {"x": np.dtype(np.float64), "_hidden": np.dtype(np.float64)})
         s = str(p)
         assert "hidden" in s
 
@@ -88,20 +86,20 @@ class TestFrozenArrayMappingShapeCheck:
 
 class TestParticles:
     def test_creates_zero_arrays(self) -> None:
-        p = Particles(4, x=np.dtype(np.float64))
+        p = Particles(4, {"x": np.dtype(np.float64)})
         np.testing.assert_array_equal(p["x"], np.zeros(4))
 
     def test_len(self) -> None:
-        p = Particles(10, x=np.dtype(np.float64))
+        p = Particles(10, {"x": np.dtype(np.float64)})
         assert len(p) == 10
 
     def test_arrays_are_writable(self) -> None:
-        p = Particles(5, x=np.dtype(np.float64))
+        p = Particles(5, {"x": np.dtype(np.float64)})
         p["x"][0] = 42.0
         assert p["x"][0] == 42.0
 
     def test_multiple_properties(self) -> None:
-        p = Particles(3, x=np.dtype(np.float64), y=np.dtype(np.float32), status=np.dtype(np.uint8))
+        p = Particles(3, {"x": np.dtype(np.float64), "y": np.dtype(np.float32), "status": np.dtype(np.uint8)})
         assert "x" in p.arrays
         assert "y" in p.arrays
         assert "status" in p.arrays
@@ -110,7 +108,7 @@ class TestParticles:
         assert p["status"].dtype == np.uint8
 
     def test_zero_particles(self) -> None:
-        p = Particles(0, x=np.dtype(np.float64))
+        p = Particles(0, {"x": np.dtype(np.float64)})
         assert len(p) == 0
         assert p.shape == (0,)
 
@@ -122,39 +120,39 @@ class TestParticles:
 
 class TestParticlesView:
     def test_view_matches_parent_values(self) -> None:
-        p = Particles(5, x=np.dtype(np.float64))
+        p = Particles(5, {"x": np.dtype(np.float64)})
         p["x"][:] = np.arange(5, dtype=np.float64)
         view = ParticlesView(p)
         np.testing.assert_array_equal(view["x"], p["x"])
 
     def test_view_reflects_parent_changes(self) -> None:
-        p = Particles(5, x=np.dtype(np.float64))
+        p = Particles(5, {"x": np.dtype(np.float64)})
         view = ParticlesView(p)
         p["x"][2] = 99.0
         assert view["x"][2] == 99.0
 
     def test_view_is_read_only(self) -> None:
-        p = Particles(5, x=np.dtype(np.float64))
+        p = Particles(5, {"x": np.dtype(np.float64)})
         view = ParticlesView(p)
         with pytest.raises(ValueError, match="read-only"):
             view["x"][0] = 1.0
 
     def test_view_len(self) -> None:
-        p = Particles(8, x=np.dtype(np.float64))
+        p = Particles(8, {"x": np.dtype(np.float64)})
         view = ParticlesView(p)
         assert len(view) == 8
 
     def test_view_shape(self) -> None:
-        p = Particles(6, x=np.dtype(np.float64))
+        p = Particles(6, {"x": np.dtype(np.float64)})
         view = ParticlesView(p)
         assert view.shape == (6,)
 
     def test_view_dtypes(self) -> None:
-        p = Particles(3, x=np.dtype(np.float64))
+        p = Particles(3, {"x": np.dtype(np.float64)})
         view = ParticlesView(p)
         assert view.dtypes["x"] == np.dtype(np.float64)
 
     def test_view_getattr(self) -> None:
-        p = Particles(4, x=np.dtype(np.float64))
+        p = Particles(4, {"x": np.dtype(np.float64)})
         view = ParticlesView(p)
         assert isinstance(view.x, np.ndarray)

--- a/tests/particles/test_particles.py
+++ b/tests/particles/test_particles.py
@@ -85,6 +85,47 @@ class TestFrozenArrayMappingShapeCheck:
 
 
 class TestParticles:
+    def test_required_particle_properties_are_created_with_required_dtypes(self) -> None:
+        p = Particles(4, {"temperature": np.dtype(np.float32)})
+
+        assert "status" in p.arrays
+        assert "zidx" in p.arrays
+        assert "yidx" in p.arrays
+        assert "xidx" in p.arrays
+        assert p["status"].dtype == np.dtype(np.uint8)
+        assert p["zidx"].dtype == np.dtype(np.float64)
+        assert p["yidx"].dtype == np.dtype(np.float64)
+        assert p["xidx"].dtype == np.dtype(np.float64)
+
+    @pytest.mark.parametrize(
+        ("field", "bad_dtype"),
+        [
+            ("status", np.dtype(np.int32)),
+            ("zidx", np.dtype(np.float32)),
+            ("yidx", np.dtype(np.int32)),
+            ("xidx", np.dtype(np.float32)),
+        ],
+    )
+    def test_incompatible_required_field_dtype_raises_value_error(self, field: str, bad_dtype: np.dtype) -> None:
+        with pytest.raises(ValueError, match="Invalid dtype for required particle property"):
+            Particles(4, {field: bad_dtype})
+
+    def test_compatible_required_field_dtype_is_accepted(self) -> None:
+        p = Particles(
+            4,
+            {
+                "status": np.dtype(np.uint8),
+                "zidx": np.dtype(np.float64),
+                "yidx": np.dtype(np.float64),
+                "xidx": np.dtype(np.float64),
+            },
+        )
+
+        assert p["status"].dtype == np.dtype(np.uint8)
+        assert p["zidx"].dtype == np.dtype(np.float64)
+        assert p["yidx"].dtype == np.dtype(np.float64)
+        assert p["xidx"].dtype == np.dtype(np.float64)
+
     def test_creates_zero_arrays(self) -> None:
         p = Particles(4, {"x": np.dtype(np.float64)})
         np.testing.assert_array_equal(p["x"], np.zeros(4))

--- a/tests/timestepping/test_ab_timestepper.py
+++ b/tests/timestepping/test_ab_timestepper.py
@@ -18,10 +18,12 @@ def _make_clock() -> Clock:
 def _make_particles() -> Particles:
     particles = Particles(
         3,
-        status=np.dtype(np.uint8),
-        zidx=np.dtype(np.float64),
-        yidx=np.dtype(np.float64),
-        xidx=np.dtype(np.float64),
+        {
+            "status": np.dtype(np.uint8),
+            "zidx": np.dtype(np.float64),
+            "yidx": np.dtype(np.float64),
+            "xidx": np.dtype(np.float64),
+        },
     )
     particles["status"][:] = np.array(
         [


### PR DESCRIPTION
Makes status, zidx, yidx and xidx required particle properties