### PR TITLE
110 infer output datatype from particle property array if not provided

### DIFF
--- a/src/offline_particles/events/_events.py
+++ b/src/offline_particles/events/_events.py
@@ -20,7 +20,7 @@ class SimulationState:
     tidx: np.float64
     iteration: int
     wall_time: np.timedelta64
-    particles: dict[str, ParticlesView]
+    particles: Mapping[str, ParticlesView]
 
 
 type EventFunction = Callable[[SimulationState], None]

--- a/src/offline_particles/output/_output.py
+++ b/src/offline_particles/output/_output.py
@@ -20,14 +20,14 @@ class Output:
     """Class defining a single output."""
 
     particle_property: str
-    dtype: np.dtype
+    dtype: np.dtype | None
     kernels: tuple[BoundKernel, ...]
     attrs: dict[str, Any]
 
     def __init__(
         self,
         particle_property: str,
-        dtype: npt.DTypeLike = np.float64,
+        dtype: npt.DTypeLike | None = None,
         kernels: Iterable[BoundKernel] = (),
         **attrs: Any,
     ) -> None:
@@ -37,8 +37,8 @@ class Output:
         ----------
         particle_property : str
             The particle property to output.
-        dtype : npt.DTypeLike, optional
-            The data type of the output.
+        dtype : npt.DTypeLike | None, optional
+            The data type of the output. If None, the output will use the same dtype as the particle property.
         kernels : Iterable[BoundKernel], optional
             The kernels required to compute the output.
         **attrs : Any
@@ -51,7 +51,7 @@ class Output:
         It is the responsibility of the output writer to convert the computed values to the appropriate dtype or error if the conversion is not possible.
         """
         object.__setattr__(self, "particle_property", particle_property)
-        object.__setattr__(self, "dtype", np.dtype(dtype))
+        object.__setattr__(self, "dtype", np.dtype(dtype) if dtype is not None else None)
         object.__setattr__(self, "kernels", tuple(kernels))
         object.__setattr__(self, "attrs", dict(attrs))
 

--- a/src/offline_particles/output/_output.py
+++ b/src/offline_particles/output/_output.py
@@ -13,6 +13,7 @@ import numpy.typing as npt
 
 from ..events import Event, SimulationState
 from ..kernels import BoundKernel
+from ..particles import ParticlesView
 
 
 @dataclasses.dataclass(frozen=True, slots=True, init=False)
@@ -342,15 +343,15 @@ class AbstractOutputWriterBuilder(abc.ABC):
     @abc.abstractmethod
     def build(
         self,
-        nparticles: dict[str, int],
+        particles: dict[str, ParticlesView],
         time_type: npt.DTypeLike,
     ) -> AbstractOutputWriter:
         """Build the output writer.
 
         Parameters
         ----------
-        nparticles : dict[str, int]
-            A mapping of particle set names to number of particles.
+        particles : dict[str, ParticlesView]
+            A mapping of particle set names to particle instances.
         time_type : npt.DTypeLike
             The numpy dtype for the time variable.
         """

--- a/src/offline_particles/output/_zarr_writer.py
+++ b/src/offline_particles/output/_zarr_writer.py
@@ -12,6 +12,7 @@ import zarr
 import zarr.storage
 
 from ..events import SimulationState
+from ..particles import ParticlesView
 from ._output import AbstractOutputWriter, AbstractOutputWriterBuilder, Output, TwoKeyDict
 
 DEFAULT_CHUNKSIZE = 250_000
@@ -400,11 +401,11 @@ class ZarrOutputBuilder(AbstractOutputWriterBuilder):
 
         del self._static_outputs[key]
 
-    def build(self, nparticles: dict[str, int], time_type: npt.DTypeLike = np.float64) -> ZarrOutputWriter:
+    def build(self, particles: dict[str, ParticlesView], time_type: npt.DTypeLike = np.float64) -> ZarrOutputWriter:
         # validate particle_sets
         for particle_set in itertools.chain(self._outputs.outer_keys(), self._static_outputs.outer_keys()):
-            if particle_set not in nparticles:
-                raise KeyError(f"Number of particles for particle set '{particle_set}' not provided.")
+            if particle_set not in particles:
+                raise KeyError(f"Particles for particle set '{particle_set}' not provided.")
 
         # initialise time array for each particle set group
         time_arrays = {
@@ -418,7 +419,7 @@ class ZarrOutputBuilder(AbstractOutputWriterBuilder):
                 overwrite=self._overwrite,
                 **self._time_array_kwargs,
             )
-            for particle_set in nparticles
+            for particle_set in particles
         }
 
         # create output arrays
@@ -426,13 +427,13 @@ class ZarrOutputBuilder(AbstractOutputWriterBuilder):
         for (particle_set, name), zarr_output_def in self._outputs.items():
             output = zarr_output_def.output
             kwargs = zarr_output_def.kwargs.copy()
-            num_particles = nparticles[particle_set]
+            property_array = particles[particle_set][output.particle_property]
 
             # create output array
             array_name = kwargs.pop("name", name)
             outputs[particle_set, name] = ZarrOutputArray(
                 output,
-                self._initialize_output_array(particle_set, array_name, output, num_particles, kwargs),
+                self._initialize_output_array(particle_set, array_name, output, property_array, kwargs),
             )
 
         # create static output arrays (1D, written once)
@@ -440,15 +441,13 @@ class ZarrOutputBuilder(AbstractOutputWriterBuilder):
         for (particle_set, name), zarr_output_def in self._static_outputs.items():
             output = zarr_output_def.output
             kwargs = zarr_output_def.kwargs.copy()
-
-            # get nparticles for this particle set
-            num_particles = nparticles[particle_set]
+            property_array = particles[particle_set][output.particle_property]
 
             # create static output array
             array_name = kwargs.pop("name", name)
             static_outputs[particle_set, name] = ZarrOutputArray(
                 output,
-                self._initialize_static_output_array(particle_set, array_name, output, num_particles, kwargs),
+                self._initialize_static_output_array(particle_set, array_name, output, property_array, kwargs),
             )
 
         return ZarrOutputWriter(
@@ -460,7 +459,7 @@ class ZarrOutputBuilder(AbstractOutputWriterBuilder):
         )
 
     def _initialize_output_array(
-        self, particle_set: str, name: str, output: Output, nparticles: int, array_kwargs: dict[str, Any]
+        self, particle_set: str, name: str, output: Output, property_array: npt.NDArray, array_kwargs: dict[str, Any]
     ) -> zarr.Array:
         """Initialize Zarr array for output.
 
@@ -472,8 +471,8 @@ class ZarrOutputBuilder(AbstractOutputWriterBuilder):
             The name of the output variable.
         output : Output
             The output definition.
-        nparticles : int
-            The number of particles in the particle set.
+        property_array : npt.NDArray
+            The array containing the particle property values.
         array_kwargs : dict[str, Any]
             Additional keyword arguments passed to Zarr.create_array.
 
@@ -483,15 +482,19 @@ class ZarrOutputBuilder(AbstractOutputWriterBuilder):
             The created Zarr array for the output.
         """
         # set shape and chunks
+        nparticles = property_array.size
         shape = (0, nparticles)
         chunks = (1, min(self._chunksize, nparticles))
+
+        # dtype
+        dtype = output.dtype if output.dtype is not None else property_array.dtype
 
         # create array
         array = zarr.create_array(
             self._store,
             name=f"{particle_set}/{name}",
             shape=shape,
-            dtype=output.dtype,
+            dtype=dtype,
             chunks=chunks,
             attributes=output.attrs,
             dimension_names=(self._time_name, particle_set),
@@ -501,7 +504,7 @@ class ZarrOutputBuilder(AbstractOutputWriterBuilder):
         return array
 
     def _initialize_static_output_array(
-        self, particle_set: str, name: str, output: Output, nparticles: int, array_kwargs: dict[str, Any]
+        self, particle_set: str, name: str, output: Output, property_array: npt.NDArray, array_kwargs: dict[str, Any]
     ) -> zarr.Array:
         """Initialize Zarr array for a static (time-independent) output.
 
@@ -513,8 +516,8 @@ class ZarrOutputBuilder(AbstractOutputWriterBuilder):
             The name of the output variable.
         output : Output
             The output definition.
-        nparticles : int
-            The number of particles in the particle set.
+        property_array : npt.NDArray
+            The array containing the particle property values.
         array_kwargs : dict[str, Any]
             Additional keyword arguments passed to Zarr.create_array.
 
@@ -524,15 +527,19 @@ class ZarrOutputBuilder(AbstractOutputWriterBuilder):
             The created Zarr array for the static output.
         """
         # set shape and chunks (1D: particles only)
+        nparticles = property_array.size
         shape = (nparticles,)
         chunks = (max(1, min(self._chunksize, nparticles)),)
+
+        # dtype
+        dtype = output.dtype if output.dtype is not None else property_array.dtype
 
         # create array
         array = zarr.create_array(
             self._store,
             name=f"{particle_set}/{name}",
             shape=shape,
-            dtype=output.dtype,
+            dtype=dtype,
             chunks=chunks,
             attributes=output.attrs,
             dimension_names=(particle_set,),

--- a/src/offline_particles/simulation.py
+++ b/src/offline_particles/simulation.py
@@ -906,6 +906,7 @@ class SimulationBuilder:
         ------
         ValueError
             If an output writer with the same name already exists.
+            If neither or both of ``n`` and ``dt`` are specified.
         """
         name = builder.name
         if name in self._output_writer_builders:
@@ -930,6 +931,11 @@ class SimulationBuilder:
 
     def build_simulation(self, *, bbox_history_size: int = DEFAULT_BBOX_HISTORY_SIZE) -> Simulation:
         """Build and return the Simulation.
+
+        Parameters
+        ----------
+        bbox_history_size : int, optional
+            The number of bounding-box snapshots to retain for the launcher (default: ``DEFAULT_BBOX_HISTORY_SIZE``).
 
         Returns
         -------

--- a/src/offline_particles/simulation.py
+++ b/src/offline_particles/simulation.py
@@ -21,7 +21,7 @@ from .events import (
 from .fieldset import Fieldset
 from .kernels import BoundKernel, construct_validation_kernel_from_bbox
 from .launcher import Launcher, Tinfo
-from .output import AbstractOutputWriter, AbstractOutputWriterBuilder
+from .output import AbstractOutputWriter, AbstractOutputWriterBuilder, Output
 from .particles import Particles, ParticlesView
 from .timestepping import Clock, D, T, Timestepper
 
@@ -46,7 +46,9 @@ class Simulation:
         self,
         clock: Clock,
         fieldset: Fieldset,
-        particle_sets: list[ParticleSet],
+        timesteppers: Mapping[str, Timestepper],
+        particles: Mapping[str, Particles],
+        particles_view: Mapping[str, ParticlesView],
         recurring_iteration_scheduler: RecurringIterationScheduler,
         recurring_time_scheduler: RecurringTimeScheduler,
         at_iteration_scheduler: AtIterationScheduler,
@@ -63,8 +65,12 @@ class Simulation:
             The Clock governing simulation time and iteration.
         fieldset : Fieldset
             The Fieldset providing velocity and other field data.
-        particle_sets : list[ParticleSet]
-            List of ParticleSet instances defining particle groups.
+        timesteppers : Mapping[str, Timestepper]
+            Mapping of timestepper instances keyed by particle set name.
+        particles : Mapping[str, Particles]
+            Mapping of particle instances keyed by particle set name.
+        particles_view : Mapping[str, ParticlesView]
+            Mapping of particle view instances keyed by particle set name.
         recurring_iteration_scheduler : RecurringIterationScheduler
             Scheduler that fires events every N iterations.
         recurring_time_scheduler : RecurringTimeScheduler
@@ -78,11 +84,6 @@ class Simulation:
         bbox_history_size : int, optional
             Number of bounding-box snapshots to retain for the launcher.
 
-        Raises
-        ------
-        ValueError
-            If particle set names are not unique.
-
         Notes
         -----
             Use :class:`SimulationBuilder` to construct a simulation rather
@@ -90,58 +91,23 @@ class Simulation:
         """
         self._clock = clock
         self._fieldset = fieldset
+        self._timesteppers = timesteppers
+        self._particles = particles
+        self._particles_view = particles_view
         self._recurring_iteration_scheduler = recurring_iteration_scheduler
         self._recurring_time_scheduler = recurring_time_scheduler
         self._at_iteration_scheduler = at_iteration_scheduler
         self._at_time_scheduler = at_time_scheduler
         self._output_writers = output_writers
 
-        # create launcher and register kernel data functions
+        # create launcher the register scalar data sources and set index padding
         self._launcher = Launcher(fieldset, history_size=bbox_history_size)
         self._launcher.register_scalar_data_sources_from_object(clock)
+        for timestepper in self._timesteppers.values():
+            self._launcher.register_scalar_data_sources_from_object(timestepper)
+            self._launcher.set_index_padding(timestepper.index_padding)
         for event in self.events:
             self._launcher.register_scalar_data_sources_from_object(event)
-
-        # check particle set names are unique
-        particle_set_names = [pset.name for pset in particle_sets]
-        if len(particle_set_names) != len(set(particle_set_names)):
-            raise ValueError("Particle set names must be unique.")
-
-        # store timesteppers by name
-        self._timesteppers = {pset.name: pset.timestepper for pset in particle_sets}
-        for timestepper in self._timesteppers.values():
-            self._launcher.set_index_padding(timestepper.index_padding)
-
-        # now build particles
-        self._particles = {}
-        self._particles_view = {}
-
-        # build particles
-        kernel_count = 0
-        for pset in particle_sets:
-            name = pset.name
-            nparticles = pset.nparticles
-            # gather kernels
-            kernels = list(pset.timestepper.kernels)
-            for event in self.events:
-                kernels.extend(event.kernels.get(name, ()))
-            kernel_count += len(kernels)
-
-            # then merge required particle properties from all kernels
-            self._particles[name] = Particles.build_from_kernels(nparticles, pset.property_dtypes, kernels)
-            self._particles_view[name] = ParticlesView(self._particles[name])
-
-        # print a warning if kernel count is larger that history size
-        if kernel_count > bbox_history_size:
-            warnings.warn(
-                f"Number of kernels ({kernel_count}) "
-                f"exceeds bbox history size ({bbox_history_size}). "
-                "Consider increasing the history size for better performance.",
-                RuntimeWarning,
-            )
-
-        # store the current wall time
-        self._wall_time_start = time.perf_counter_ns()
 
         # stopping conditions
         # Default: stop at the chronological end of the time array
@@ -149,6 +115,9 @@ class Simulation:
         self._time_stop = None
         self._wall_time_stop = None
         self.set_time_stop(self._clock.final_time)
+
+        # store the current wall time
+        self._wall_time_start = time.perf_counter_ns()
 
     # getters
 
@@ -686,14 +655,39 @@ class SimulationBuilder:
     ) -> None:
         """Class for building a Simulation.
 
-        Args:
-            clock: The clock to use in the simulation.
-            fieldset: The fieldset to use in the simulation.
-            particle_sets: The particle sets to include in the simulation.
+        Parameters
+        ----------
+        clock : Clock
+            The clock to use in the simulation.
+        fieldset : Fieldset
+            The fieldset to use in the simulation.
+        *particle_sets : ParticleSet
+            The particle sets to include in the simulation.
+
+        Raises
+        ------
+        ValueError
+            If particle set names are not unique.
         """
         self._clock = clock
         self._fieldset = fieldset
+
+        # check particle set names are unique then store
+        particle_set_names = [pset.name for pset in particle_sets]
+        if len(particle_set_names) != len(set(particle_set_names)):
+            raise ValueError("Particle set names must be unique.")
         self._particle_sets = list(particle_sets)
+
+        # timesteppers
+        self._timesteppers = {}
+        for pset in particle_sets:
+            timestepper = pset.timestepper
+            # add validation kernel if requested - note this is cached so only constructed once per unique bbox
+            if pset.include_validation_kernel:
+                validation_kernel = construct_validation_kernel_from_bbox(self._fieldset.domain_bbox)
+                timestepper.add_validation_kernels(validation_kernel)
+            # store timestepper
+            self._timesteppers[pset.name] = timestepper
 
         # events
         self._recurring_iteration_scheduler = RecurringIterationScheduler()
@@ -702,7 +696,24 @@ class SimulationBuilder:
         self._at_time_scheduler = AtTimeScheduler(forward_in_time=self._clock.forward_in_time)
 
         # output writers
-        self._output_writers: dict[str, tuple[AbstractOutputWriterBuilder, dict[str, ...]]] = {}
+        self._output_writer_builders: dict[str, AbstractOutputWriterBuilder] = {}
+        self._output_writer_scheduling_args: dict[str, dict[str, ...]] = {}
+
+    def collect_outputs(self) -> Mapping[str, list[Output]]:
+        """Collect a list of outputs registered to particle sets across all writers.
+
+        Returns
+        -------
+        Mapping[str, list[Output]]
+            A mapping from particle set name to a list of outputs registered across all writers.
+        """
+        outputs_by_particle_set: dict[str, list[Output]] = {pset.name: [] for pset in self._particle_sets}
+        for writer_builder in self._output_writer_builders.values():
+            for (pset_name, _), output in writer_builder.outputs:
+                outputs_by_particle_set[pset_name].append(output)
+            for (pset_name, _), output in writer_builder.static_outputs:
+                outputs_by_particle_set[pset_name].append(output)
+        return types.MappingProxyType(outputs_by_particle_set)
 
     @property
     def events(self) -> Iterable[Event]:
@@ -735,6 +746,7 @@ class SimulationBuilder:
             raise ValueError("n must be a positive integer.")
         if first is None:
             first = 0
+
         self._recurring_iteration_scheduler.register_event(first, n, event)
 
     def every_dt(self, dt: D, event: Event, *, first: T | None = None) -> None:
@@ -830,12 +842,15 @@ class SimulationBuilder:
         ValueError
             If neither or both of ``n`` and ``dt`` are specified.
         """
-        if (n is None) == (dt is None):
-            raise ValueError("Exactly one of n or dt must be specified.")
-        if n is not None:
-            self.every_n(n, event, first=first)  # type: ignore[arg-type]
-        else:
-            self.every_dt(dt, event, first=first)  # type: ignore[arg-type]
+        match n, dt:
+            case None, None:
+                raise ValueError("Exactly one of n or dt must be specified.")
+            case _, None:
+                self.every_n(n, event, first=first)  # type: ignore[arg-type]
+            case None, _:
+                self.every_dt(dt, event, first=first)  # type: ignore[arg-type]
+            case _:
+                raise ValueError("Exactly one of n or dt must be specified.")
 
     def add_event(self, event: Event, *, at_iteration: int | None = None, at_time: T | None = None) -> None:
         """Add a one-shot event to the simulation.
@@ -856,12 +871,15 @@ class SimulationBuilder:
         ValueError
             If neither or both of ``at_iteration`` and ``at_time`` are specified.
         """
-        if (at_iteration is None) == (at_time is None):
-            raise ValueError("Exactly one of at_iteration or at_time must be specified.")
-        if at_iteration is not None:
-            self.at_iteration(at_iteration, event)
-        else:
-            self.at_time(at_time, event)  # type: ignore[arg-type]
+        match at_iteration, at_time:
+            case None, None:
+                raise ValueError("Exactly one of at_iteration or at_time must be specified.")
+            case _, None:
+                self.at_iteration(at_iteration, event)  # type: ignore[arg-type]
+            case None, _:
+                self.at_time(at_time, event)  # type: ignore[arg-type]
+            case _:
+                raise ValueError("Exactly one of at_iteration or at_time must be specified.")
 
     def add_output_writer(
         self,
@@ -890,17 +908,27 @@ class SimulationBuilder:
             If an output writer with the same name already exists.
         """
         name = builder.name
-        if name in self._output_writers:
+        if name in self._output_writer_builders:
             raise ValueError(f"Output writer '{name}' already exists.")
 
-        kwargs = {
-            "n": n,
-            "dt": dt,
-            "first": first,
-        }
-        self._output_writers[name] = (builder, kwargs)
+        match n, dt:
+            case None, None:
+                raise ValueError("Exactly one of n or dt must be specified.")
+            case _, None:
+                if first is None:
+                    first = 0
+                scheduling_args = {"n": n, "first": first}  # type: ignore
+            case None, _:
+                if first is None:
+                    first = self._clock.time
+                scheduling_args = {"dt": dt, "first": first}  # type: ignore
+            case _:
+                raise ValueError("Exactly one of n or dt must be specified.")
 
-    def build_simulation(self) -> Simulation:
+        self._output_writer_builders[name] = builder
+        self._output_writer_scheduling_args[name] = scheduling_args
+
+    def build_simulation(self, *, bbox_history_size: int = DEFAULT_BBOX_HISTORY_SIZE) -> Simulation:
         """Build and return the Simulation.
 
         Returns
@@ -908,33 +936,73 @@ class SimulationBuilder:
         Simulation
             The constructed Simulation instance.
         """
-        # add validation kernels to timesteppers if requested
-        for pset in self._particle_sets:
-            if pset.include_validation_kernel:
-                # construct validation kernel - note this is cached
-                validation_kernel = construct_validation_kernel_from_bbox(self._fieldset.domain_bbox)
-                pset.timestepper.add_validation_kernels(validation_kernel)
+        # to build the particles we need to gather all the kernels
+        # first collect the outputs
+        outputs = self.collect_outputs()
 
-        # build output writers, construct events and make mapping immutable
-        output_writers = {}
+        # then initialise the particles dict
+        particles = {}
+        particles_view = {}
+
+        # keep track of total kernel count across all particle sets for warning about bbox history size
+        kernel_count = 0
+
+        # loop over particle sets
+        for pset in self._particle_sets:
+            name = pset.name
+            nparticles = pset.nparticles
+
+            # gather kernels from timesteppers
+            kernels = list(self._timesteppers[name].kernels)
+            # then gather kernels from events
+            for event in self.events:
+                kernels.extend(event.kernels.get(name, ()))
+            # finally from outputs
+            for output in outputs.get(name, ()):
+                kernels.extend(output.kernels)
+
+            kernel_count += len(kernels)
+
+            particles[name] = Particles.build_from_kernels(nparticles, pset.property_dtypes, kernels)
+            particles_view[name] = ParticlesView(particles[name])
+
+        # print a warning if kernel count is larger that history size
+        if kernel_count > bbox_history_size:
+            warnings.warn(
+                f"Number of kernels ({kernel_count}) "
+                f"exceeds bbox history size ({bbox_history_size}). "
+                "Consider increasing the history size for better performance.",
+                RuntimeWarning,
+            )
+
+        # next build the output writers and register their events
+        built_output_writers = {}
         time_type = self._clock.time_array.dtype
-        nparticles = {pset.name: pset.nparticles for pset in self._particle_sets}
-        for name, (builder, kwargs) in self._output_writers.items():
-            output_writers[name] = builder.build(nparticles, time_type)
-            for event in output_writers[name].create_output_events():
-                self.add_recurring_event(event, n=kwargs.get("n"), dt=kwargs.get("dt"), first=kwargs.get("first"))
+
+        for name, builder in self._output_writer_builders.items():
+            built_output_writers[name] = builder.build(particles_view, time_type)
+
+            # register recurring output events
+            scheduling_args = self._output_writer_scheduling_args.get(name, {})
+            for event in built_output_writers[name].create_output_events():
+                self.add_recurring_event(event, **scheduling_args)
+
             # register static output events once at iteration 0
-            for event in output_writers[name].create_static_output_events():
+            for event in built_output_writers[name].create_static_output_events():
                 self.at_iteration(0, event)
-        output_writers = types.MappingProxyType(output_writers)
+
+        output_writers = types.MappingProxyType(built_output_writers)
 
         return Simulation(
             clock=self._clock,
             fieldset=self._fieldset,
-            particle_sets=self._particle_sets,
+            timesteppers=types.MappingProxyType(self._timesteppers),
+            particles=types.MappingProxyType(particles),
+            particles_view=types.MappingProxyType(particles_view),
             recurring_iteration_scheduler=self._recurring_iteration_scheduler,
             recurring_time_scheduler=self._recurring_time_scheduler,
             at_iteration_scheduler=self._at_iteration_scheduler,
             at_time_scheduler=self._at_time_scheduler,
             output_writers=output_writers,
+            bbox_history_size=bbox_history_size,
         )

--- a/src/offline_particles/simulation.py
+++ b/src/offline_particles/simulation.py
@@ -100,7 +100,7 @@ class Simulation:
         self._at_time_scheduler = at_time_scheduler
         self._output_writers = output_writers
 
-        # create launcher the register scalar data sources and set index padding
+        # create launcher then register scalar data sources and set index padding
         self._launcher = Launcher(fieldset, history_size=bbox_history_size)
         self._launcher.register_scalar_data_sources_from_object(clock)
         for timestepper in self._timesteppers.values():

--- a/tests/output/_helpers.py
+++ b/tests/output/_helpers.py
@@ -1,0 +1,36 @@
+"""Helpers for output tests."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from offline_particles.particles import Particles, ParticlesView
+
+
+def make_particles_view(nparticles: int, property_values: dict[str, np.ndarray] | None = None) -> ParticlesView:
+    """Create a ``ParticlesView`` for testing output builders.
+
+    Parameters
+    ----------
+    nparticles : int
+        The number of particles to allocate.
+    property_values : dict[str, np.ndarray] | None, optional
+        Property arrays to seed into the particle set.
+
+    Returns
+    -------
+    ParticlesView
+        A read-only view of the constructed particles.
+    """
+    property_dtypes: dict[str, np.dtype] = {"xidx": np.dtype(np.float64), "yidx": np.dtype(np.float64)}
+    if property_values:
+        for name, values in property_values.items():
+            property_dtypes[name] = np.asarray(values).dtype
+
+    particles = Particles(nparticles, property_dtypes)
+
+    if property_values:
+        for name, values in property_values.items():
+            particles[name][:] = np.asarray(values, dtype=particles[name].dtype)
+
+    return ParticlesView(particles)

--- a/tests/output/test_dtype_inference.py
+++ b/tests/output/test_dtype_inference.py
@@ -1,0 +1,52 @@
+"""Tests for output dtype inference from particle properties."""
+
+import numpy as np
+import zarr
+import zarr.storage
+
+from offline_particles.output import Output, ZarrOutputBuilder
+from tests.output._helpers import make_particles_view
+
+
+def _make_builder(store: zarr.storage.StoreLike) -> ZarrOutputBuilder:
+    return ZarrOutputBuilder("test_writer", store)
+
+
+class TestZarrOutputBuilderDtypeInference:
+    def test_time_dependent_output_uses_particle_property_dtype_when_dtype_is_none(self) -> None:
+        store = zarr.storage.MemoryStore()
+        builder = _make_builder(store)
+        builder.add_output("particles", "x", Output("mass", dtype=None))
+
+        builder.build({"particles": make_particles_view(4, {"mass": np.array([1, 2, 3, 4], dtype=np.int16)})})
+
+        group = zarr.open_group(store, mode="r")
+        output_array = group["particles"]["x"]  # type: ignore[invalid-argument-type]
+        assert isinstance(output_array, zarr.Array)
+        assert output_array.dtype == np.dtype(np.int16)
+
+    def test_static_output_uses_particle_property_dtype_when_dtype_is_none(self) -> None:
+        store = zarr.storage.MemoryStore()
+        builder = _make_builder(store)
+        builder.add_static_output("particles", "density", Output("temperature", dtype=None))
+
+        builder.build({
+            "particles": make_particles_view(4, {"temperature": np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)})
+        })
+
+        group = zarr.open_group(store, mode="r")
+        output_array = group["particles"]["density"]  # type: ignore[invalid-argument-type]
+        assert isinstance(output_array, zarr.Array)
+        assert output_array.dtype == np.dtype(np.float32)
+
+    def test_explicit_dtype_overrides_particle_property_dtype(self) -> None:
+        store = zarr.storage.MemoryStore()
+        builder = _make_builder(store)
+        builder.add_output("particles", "x", Output("mass", dtype=np.float32))
+
+        builder.build({"particles": make_particles_view(4, {"mass": np.array([1, 2, 3, 4], dtype=np.int16)})})
+
+        group = zarr.open_group(store, mode="r")
+        output_array = group["particles"]["x"]  # type: ignore[invalid-argument-type]
+        assert isinstance(output_array, zarr.Array)
+        assert output_array.dtype == np.dtype(np.float32)

--- a/tests/output/test_output.py
+++ b/tests/output/test_output.py
@@ -7,9 +7,9 @@ from offline_particles.output import Output
 
 
 class TestOutputConstruction:
-    def test_default_dtype_is_float64(self) -> None:
+    def test_default_dtype_is_none(self) -> None:
         output = Output("xidx")
-        assert output.dtype == np.dtype(np.float64)
+        assert output.dtype is None
 
     def test_explicit_dtype(self) -> None:
         output = Output("xidx", dtype=np.float32)

--- a/tests/output/test_static_output.py
+++ b/tests/output/test_static_output.py
@@ -7,7 +7,7 @@ import zarr.storage
 
 from offline_particles.events import SimulationState
 from offline_particles.output import Output, ZarrOutputBuilder
-from offline_particles.particles import Particles, ParticlesView
+from tests.output._helpers import make_particles_view
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -30,24 +30,13 @@ def _make_state(nparticles: int = 5, property_values: dict | None = None) -> Sim
     SimulationState
         A SimulationState object with the specified number of particles and property values.
     """
-    kwargs: dict = {"xidx": np.dtype(np.float64), "yidx": np.dtype(np.float64)}
-    if property_values:
-        for name, values in property_values.items():
-            kwargs[name] = np.asarray(values).dtype
-
-    particles = Particles(nparticles, kwargs)
-
-    if property_values:
-        for name, values in property_values.items():
-            particles[name][:] = np.asarray(values, dtype=particles[name].dtype)
-
     return SimulationState(
         time=np.float64(0.0),
         dt=np.float64(1.0),
         tidx=np.float64(0.0),
         iteration=0,
         wall_time=np.timedelta64(0, "ns"),
-        particles={"particles": ParticlesView(particles)},
+        particles={"particles": make_particles_view(nparticles, property_values)},
     )
 
 
@@ -161,7 +150,7 @@ class TestZarrOutputWriterStaticOutputArrays:
         builder = _make_builder(store)
         builder.add_static_output("particles", "density", _make_output("xidx"))
 
-        builder.build({"particles": 5})
+        builder.build({"particles": make_particles_view(5)})
 
         # The static output array should be 1D with shape (nparticles,)
         group = zarr.open_group(store, mode="r")
@@ -176,7 +165,7 @@ class TestZarrOutputWriterStaticOutputArrays:
         builder = _make_builder(store)
         builder.add_output("particles", "x", _make_output("xidx"))
 
-        builder.build({"particles": 5})
+        builder.build({"particles": make_particles_view(5)})
 
         group = zarr.open_group(store, mode="r")
         assert "x" in group["particles"]
@@ -191,7 +180,7 @@ class TestZarrOutputWriterStaticOutputArrays:
         output = _make_output("xidx")
         builder.add_static_output("particles", "density", output)
 
-        writer = builder.build({"particles": 5})
+        writer = builder.build({"particles": make_particles_view(5)})
 
         assert ("particles", "density") in dict(writer.static_outputs)
         assert dict(writer.static_outputs)[("particles", "density")] is output
@@ -201,7 +190,7 @@ class TestZarrOutputWriterStaticOutputArrays:
         builder = _make_builder(store)
         builder.add_static_output("particles", "density", _make_output("xidx"))
 
-        writer = builder.build({"particles": 5})
+        writer = builder.build({"particles": make_particles_view(5)})
 
         assert ("particles", "density") not in dict(writer.outputs)
 
@@ -217,7 +206,7 @@ class TestZarrOutputWriterWriteStaticOutput:
         builder = _make_builder(store)
         builder.add_static_output("particles", "density", _make_output("xidx"))
 
-        writer = builder.build({"particles": 5})
+        writer = builder.build({"particles": make_particles_view(5)})
 
         values = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
         state = _make_state(5, {"xidx": values, "yidx": np.zeros(5)})
@@ -232,7 +221,7 @@ class TestZarrOutputWriterWriteStaticOutput:
     def test_write_static_output_missing_key_raises(self) -> None:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
-        writer = builder.build({"particles": 5})
+        writer = builder.build({"particles": make_particles_view(5)})
 
         state = _make_state(5, {"xidx": np.zeros(5), "yidx": np.zeros(5)})
 
@@ -245,7 +234,7 @@ class TestZarrOutputWriterWriteStaticOutput:
         builder.add_output("particles", "x", _make_output("xidx"))
         builder.add_static_output("particles", "density", _make_output("yidx"))
 
-        writer = builder.build({"particles": 3})
+        writer = builder.build({"particles": make_particles_view(3)})
         state = _make_state(3, {"xidx": np.ones(3), "yidx": np.array([10.0, 20.0, 30.0])})
 
         writer.write_static_output("particles", "density", state)
@@ -266,7 +255,7 @@ class TestCreateStaticOutputEvents:
     def test_create_static_output_events_empty_when_no_static_outputs(self) -> None:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
-        writer = builder.build({"particles": 5})
+        writer = builder.build({"particles": make_particles_view(5)})
         events = writer.create_static_output_events()
         assert events == []
 
@@ -276,7 +265,7 @@ class TestCreateStaticOutputEvents:
         builder.add_static_output("particles", "density", _make_output("xidx"))
         builder.add_static_output("particles", "release_time", _make_output("yidx"))
 
-        writer = builder.build({"particles": 5})
+        writer = builder.build({"particles": make_particles_view(5)})
         events = writer.create_static_output_events()
 
         assert len(events) == 2
@@ -286,7 +275,7 @@ class TestCreateStaticOutputEvents:
         builder = _make_builder(store)
         builder.add_static_output("particles", "density", _make_output("xidx"))
 
-        writer = builder.build({"particles": 5})
+        writer = builder.build({"particles": make_particles_view(5)})
         events = writer.create_static_output_events()
 
         assert len(events) == 1
@@ -297,7 +286,7 @@ class TestCreateStaticOutputEvents:
         builder = _make_builder(store)
         builder.add_static_output("particles", "density", _make_output("xidx"))
 
-        writer = builder.build({"particles": 5})
+        writer = builder.build({"particles": make_particles_view(5)})
         events = writer.create_static_output_events()
 
         values = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
@@ -317,7 +306,7 @@ class TestCreateStaticOutputEvents:
         builder.add_output("particles", "x", _make_output("xidx"))
         builder.add_static_output("particles", "density", _make_output("yidx"))
 
-        writer = builder.build({"particles": 5})
+        writer = builder.build({"particles": make_particles_view(5)})
         recurring_events = writer.create_output_events()
         static_events = writer.create_static_output_events()
 
@@ -334,7 +323,7 @@ class TestCreateStaticOutputEvents:
         builder = _make_builder(store)
         builder.add_static_output("particles", "density", _make_output("xidx"))
 
-        builder.build({"particles": 5})
+        builder.build({"particles": make_particles_view(5)})
 
         group = zarr.open_group(store, mode="r")
         density_arr = group["particles"]["density"]  # type: ignore[invalid-argument-type]

--- a/tests/output/test_time_dependent_output.py
+++ b/tests/output/test_time_dependent_output.py
@@ -8,6 +8,7 @@ import zarr.storage
 from offline_particles.events import SimulationState
 from offline_particles.output import Output, ZarrOutputBuilder
 from offline_particles.particles import Particles, ParticlesView
+from tests.output._helpers import make_particles_view
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -117,7 +118,7 @@ class TestZarrOutputBuilderBuild:
     def test_build_creates_time_array(self) -> None:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
-        builder.build({"particles": 5})
+        builder.build({"particles": make_particles_view(5)})
 
         group = zarr.open_group(store, mode="r")
         assert "time" in group["particles"]
@@ -128,7 +129,7 @@ class TestZarrOutputBuilderBuild:
     def test_build_creates_groups_for_each_particle_set(self) -> None:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
-        builder.build({"ps1": 3, "ps2": 5})
+        builder.build({"ps1": make_particles_view(3), "ps2": make_particles_view(5)})
 
         group = zarr.open_group(store, mode="r")
         assert "time" in group["ps1"]
@@ -139,19 +140,19 @@ class TestZarrOutputBuilderBuild:
         builder = _make_builder(store)
         builder.add_output("unknown_ps", "x", Output("xidx"))
         with pytest.raises(KeyError, match="unknown_ps"):
-            builder.build({"particles": 5})
+            builder.build({"particles": make_particles_view(5)})
 
     def test_build_static_output_for_unknown_particle_set_raises(self) -> None:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
         builder.add_static_output("unknown_ps", "density", Output("xidx"))
         with pytest.raises(KeyError, match="unknown_ps"):
-            builder.build({"particles": 5})
+            builder.build({"particles": make_particles_view(5)})
 
     def test_time_array_dimension_name(self) -> None:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
-        builder.build({"particles": 5})
+        builder.build({"particles": make_particles_view(5)})
 
         group = zarr.open_group(store, mode="r")
         time_arr = group["particles"]["time"]  # type: ignore[invalid-argument-type]
@@ -163,7 +164,7 @@ class TestZarrOutputBuilderBuild:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
         builder.add_output("particles", "x", Output("xidx"))
-        builder.build({"particles": 5})
+        builder.build({"particles": make_particles_view(5)})
 
         group = zarr.open_group(store, mode="r")
         x_arr = group["particles"]["x"]  # type: ignore[invalid-argument-type]
@@ -194,7 +195,7 @@ class TestZarrOutputWriterWriteTime:
     def test_write_time_appends_to_time_array(self) -> None:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
-        writer = builder.build({"particles": 3})
+        writer = builder.build({"particles": make_particles_view(3)})
 
         state = _make_state(time=5.0)
         writer.write_time(state)
@@ -205,7 +206,7 @@ class TestZarrOutputWriterWriteTime:
     def test_write_time_appends_multiple_values(self) -> None:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
-        writer = builder.build({"particles": 3})
+        writer = builder.build({"particles": make_particles_view(3)})
 
         for t in [0.0, 1.0, 2.0]:
             state = _make_state(time=t)
@@ -219,7 +220,7 @@ class TestZarrOutputWriterWriteTime:
         builder = _make_builder(store)
         builder.add_output("ps1", "x", Output("xidx"))
         builder.add_output("ps2", "x", Output("xidx"))
-        writer = builder.build({"ps1": 3, "ps2": 2})
+        writer = builder.build({"ps1": make_particles_view(3), "ps2": make_particles_view(2)})
 
         state = _make_multi_set_state(time=7.0)
         writer.write_time(state)
@@ -239,7 +240,7 @@ class TestZarrOutputWriterWriteOutput:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
         builder.add_output("particles", "x", Output("xidx"))
-        writer = builder.build({"particles": 3})
+        writer = builder.build({"particles": make_particles_view(3)})
 
         values = np.array([1.0, 2.0, 3.0])
         state = _make_state(3, {"xidx": values})
@@ -255,7 +256,7 @@ class TestZarrOutputWriterWriteOutput:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
         builder.add_output("particles", "x", Output("xidx"))
-        writer = builder.build({"particles": 3})
+        writer = builder.build({"particles": make_particles_view(3)})
 
         for i in range(3):
             values = np.array([float(i)] * 3)
@@ -271,7 +272,7 @@ class TestZarrOutputWriterWriteOutput:
     def test_write_output_missing_key_raises(self) -> None:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
-        writer = builder.build({"particles": 3})
+        writer = builder.build({"particles": make_particles_view(3)})
 
         state = _make_state(3)
         with pytest.raises(KeyError, match="nonexistent"):
@@ -282,7 +283,7 @@ class TestZarrOutputWriterWriteOutput:
         builder = _make_builder(store)
         builder.add_output("ps1", "x", Output("xidx"))
         builder.add_output("ps2", "x", Output("xidx"))
-        writer = builder.build({"ps1": 3, "ps2": 2})
+        writer = builder.build({"ps1": make_particles_view(3), "ps2": make_particles_view(2)})
 
         state = _make_multi_set_state(
             values_ps1=[1.0, 2.0, 3.0],
@@ -305,7 +306,7 @@ class TestZarrOutputWriterFinaliseWriteRound:
     def test_finalise_increments_count(self) -> None:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
-        writer = builder.build({"particles": 3})
+        writer = builder.build({"particles": make_particles_view(3)})
 
         state = _make_state()
         writer.write_time(state)
@@ -318,7 +319,7 @@ class TestZarrOutputWriterFinaliseWriteRound:
     def test_finalise_raises_if_time_not_written(self) -> None:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
-        writer = builder.build({"particles": 3})
+        writer = builder.build({"particles": make_particles_view(3)})
 
         state = _make_state()
         with pytest.raises(RuntimeError, match="Time output"):
@@ -328,7 +329,7 @@ class TestZarrOutputWriterFinaliseWriteRound:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
         builder.add_output("particles", "x", Output("xidx"))
-        writer = builder.build({"particles": 3})
+        writer = builder.build({"particles": make_particles_view(3)})
 
         state = _make_state()
         writer.write_time(state)
@@ -346,7 +347,7 @@ class TestCreateOutputEvents:
     def test_create_output_events_includes_time_event(self) -> None:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
-        writer = builder.build({"particles": 3})
+        writer = builder.build({"particles": make_particles_view(3)})
 
         events = writer.create_output_events()
         event_names = [e.name for e in events]
@@ -355,7 +356,7 @@ class TestCreateOutputEvents:
     def test_create_output_events_includes_finalise_event(self) -> None:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
-        writer = builder.build({"particles": 3})
+        writer = builder.build({"particles": make_particles_view(3)})
 
         events = writer.create_output_events()
         event_names = [e.name for e in events]
@@ -365,7 +366,7 @@ class TestCreateOutputEvents:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
         builder.add_output("particles", "x", Output("xidx"))
-        writer = builder.build({"particles": 3})
+        writer = builder.build({"particles": make_particles_view(3)})
 
         events = writer.create_output_events()
         event_names = [e.name for e in events]
@@ -375,7 +376,7 @@ class TestCreateOutputEvents:
         """With no outputs, there should be at least time and finalise events."""
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
-        writer = builder.build({"particles": 3})
+        writer = builder.build({"particles": make_particles_view(3)})
 
         events = writer.create_output_events()
         assert len(events) >= 2
@@ -384,7 +385,7 @@ class TestCreateOutputEvents:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
         builder.add_output("particles", "x", Output("xidx"))
-        writer = builder.build({"particles": 3})
+        writer = builder.build({"particles": make_particles_view(3)})
 
         events = writer.create_output_events()
         values = np.array([10.0, 20.0, 30.0])
@@ -402,7 +403,7 @@ class TestCreateOutputEvents:
     def test_event_name_method(self) -> None:
         store = zarr.storage.MemoryStore()
         builder = _make_builder(store)
-        writer = builder.build({"particles": 3})
+        writer = builder.build({"particles": make_particles_view(3)})
 
         assert writer.event_name("particles", "x") == "test_writer:particles:x"
         assert writer.event_name("ps2", "density") == "test_writer:ps2:density"

--- a/tests/simulation/test_builder_order.py
+++ b/tests/simulation/test_builder_order.py
@@ -1,0 +1,103 @@
+"""Tests for simulation builder ordering and output-builder inputs."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from offline_particles.fieldset import Fieldset
+from offline_particles.kernels import BoundKernel, ParticleKernel, ParticlePropertyDeclaration
+from offline_particles.output import AbstractOutputWriter, AbstractOutputWriterBuilder
+from offline_particles.particles import ParticlesView
+from offline_particles.simulation import ParticleSet, SimulationBuilder
+from offline_particles.timestepping import Clock, Timestepper
+
+
+def _make_clock() -> Clock:
+    return Clock(np.array([0.0, 1.0], dtype=np.float64), np.float64(1.0))
+
+
+class _NoOpTimestepper(Timestepper):
+    def run_step(self, particles, launcher, clock) -> None:
+        pass
+
+
+def _make_mass_kernel() -> BoundKernel:
+    kernel = ParticleKernel(lambda pp, sc, fd: None, [ParticlePropertyDeclaration("mass", np.float32)])
+    return BoundKernel(kernel)
+
+
+class _RecordingWriter(AbstractOutputWriter):
+    @property
+    def name(self) -> str:
+        return "recording"
+
+    @property
+    def outputs(self):
+        return ()
+
+    @property
+    def static_outputs(self):
+        return ()
+
+    def write_time(self, state) -> None:
+        pass
+
+    def write_output(self, particle_set: str, name: str, state) -> None:
+        pass
+
+    def finalise_write_round(self, state) -> None:
+        pass
+
+    def write_static_output(self, particle_set: str, name: str, state) -> None:
+        pass
+
+
+class _RecordingBuilder(AbstractOutputWriterBuilder):
+    def __init__(self) -> None:
+        self.received_particles: ParticlesView | None = None
+        self.received_dtype: np.dtype | None = None
+
+    @property
+    def name(self) -> str:
+        return "recording"
+
+    @property
+    def outputs(self):
+        return ()
+
+    @property
+    def static_outputs(self):
+        return ()
+
+    def add_output(self, particle_set: str, name: str, output, **kwargs) -> None:
+        pass
+
+    def remove_output(self, particle_set: str, name: str) -> None:
+        pass
+
+    def add_static_output(self, particle_set: str, name: str, output, **kwargs) -> None:
+        pass
+
+    def remove_static_output(self, particle_set: str, name: str) -> None:
+        pass
+
+    def build(self, particles: dict[str, ParticlesView], time_type):
+        self.received_particles = particles["pset"]
+        self.received_dtype = particles["pset"]["mass"].dtype
+        return _RecordingWriter()
+
+
+def test_build_simulation_passes_particles_view_to_output_builder() -> None:
+    fieldset = Fieldset(1, 1, 1, 1)
+    timestepper = _NoOpTimestepper()
+    timestepper.add_pre_step_kernels(_make_mass_kernel())
+    particle_set = ParticleSet("pset", 3, timestepper, include_validation_kernel=False)
+    builder = SimulationBuilder(_make_clock(), fieldset, particle_set)
+
+    recording_builder = _RecordingBuilder()
+    builder.add_output_writer(recording_builder, n=1)
+
+    builder.build_simulation()
+
+    assert isinstance(recording_builder.received_particles, ParticlesView)
+    assert recording_builder.received_dtype == np.dtype(np.float32)


### PR DESCRIPTION
Major refactor of ``Simulation`` and ``SimulationBuilder`` class to make the ``ParticlesView`` objects available at output writer build time. This allows for the output dtype to be inferred from the particle property arrays if not specified.